### PR TITLE
Parallel CPU Runtime

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -12,6 +12,17 @@ target_include_directories(spnc-rt
 
 target_link_libraries(spnc-rt PRIVATE elf spnc-common spdlog::spdlog)
 
+option(CPU_PARALLEL_RUNTIME
+        "Enable/disable thread-parallel execution of multiple batches on CPU in the runtime"
+        ON)
+
+if (${CPU_PARALLEL_RUNTIME})
+    find_package(OpenMP REQUIRED)
+    if (OpenMP_CXX_FOUND)
+        target_link_libraries(spnc-rt PRIVATE OpenMP::OpenMP_CXX)
+    endif (OpenMP_CXX_FOUND)
+endif (${CPU_PARALLEL_RUNTIME})
+
 doxygen_doc(TARGET_NAME spnc-rt
         SRC_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/runtime/src/Executable.cpp
+++ b/runtime/src/Executable.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <util/Logging.h>
 #include "Executable.h"
+#include <omp.h>
 
 using namespace spnc_rt;
 
@@ -64,6 +65,7 @@ void Executable::executeBatch(size_t num_samples, void* inputs, void* outputs) {
   char* input_ptr = reinterpret_cast<char*>(inputs);
   char* output_ptr = reinterpret_cast<char*>(outputs);
   size_t batchSize = kernel->batchSize();
+#pragma omp parallel for firstprivate(input_ptr, output_ptr, batchSize, num_samples)
   for (size_t i = 0; i < num_samples; i += batchSize) {
     // Calculate the number of remaining samples, can be < batchSize for the last batch.
     size_t remainingSamples = num_samples - i;


### PR DESCRIPTION
This PR enables parallel execution of multiple batches on the CPU, using OpenMP multi-threading in the runtime. 

The multi-threading in the runtime can be combined with vectorization in the generated CPU kernel. 

To disable parallel execution, set the CMake flag `-DCPU_PARALLEL_RUNTIME=OFF`.