### PR TITLE
LoSPN Graph Partitioning

### DIFF
--- a/compiler/include/driver/GlobalOptions.h
+++ b/compiler/include/driver/GlobalOptions.h
@@ -39,6 +39,11 @@ namespace spnc {
     extern EnumOpt compilationTarget;
 
     ///
+    /// Option to specify the maximum size of a task. Smaller tasks typically reduce
+    /// compilation time, but can introduce overhead.
+    extern Option<int> maxTaskSize;
+
+    ///
     /// Flag to indicate whether the code generated for the CPU should be vectorized.
     extern Option<bool> cpuVectorize;
 

--- a/compiler/include/driver/GlobalOptions.h
+++ b/compiler/include/driver/GlobalOptions.h
@@ -38,6 +38,12 @@ namespace spnc {
     /// Interface option to specify the compilation target.
     extern EnumOpt compilationTarget;
 
+    extern Option<int> optLevel;
+
+    extern Option<int> irOptLevel;
+
+    extern Option<int> mcOptLevel;
+
     ///
     /// Option to specify the maximum size of a task. Smaller tasks typically reduce
     /// compilation time, but can introduce overhead.

--- a/compiler/src/codegen/mlir/conversion/MLIRtoLLVMIRConversion.cpp
+++ b/compiler/src/codegen/mlir/conversion/MLIRtoLLVMIRConversion.cpp
@@ -7,12 +7,18 @@
 //==============================================================================
 
 #include "MLIRtoLLVMIRConversion.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/IR/LegacyPassManager.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 #include <llvm/Support/TargetSelect.h>
 #include <mlir/ExecutionEngine/ExecutionEngine.h>
 #include <mlir/ExecutionEngine/OptUtils.h>
 #include <util/Logging.h>
 #include <driver/GlobalOptions.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#include <llvm/Transforms/IPO.h>
+#include <llvm/Transforms/Coroutines.h>
+#include "llvm/IR/PassTimingInfo.h"
 
 using namespace spnc;
 
@@ -35,16 +41,15 @@ llvm::Module& spnc::MLIRtoLLVMIRConversion::execute() {
       SPNC_FATAL_ERROR("Conversion to LLVM IR failed");
     }
 
+    SPDLOG_INFO("Finished conversion to LLVM IR");
+
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
     // NOTE: If we want to support cross-compilation, we need to replace the following line, as it will
     // always set the modules target triple to the native CPU target.
     mlir::ExecutionEngine::setupTargetTriple(module.get());
     // Run optimization pipeline to get rid of some clutter introduced during conversion to LLVM dialect in MLIR.
-    auto optPipeline = mlir::makeOptimizingTransformer((optimize ? 3 : 0), 0, machine.get());
-    if (auto err = optPipeline(module.get())) {
-      SPNC_FATAL_ERROR("Optimization of converted LLVM IR failed");
-    }
+    optimizeLLVMIR();
     if (optimize && spnc::option::dumpIR.get(*this->config)) {
       llvm::dbgs() << "\n// *** IR after optimization of LLVM IR ***\n";
       module->dump();
@@ -52,4 +57,45 @@ llvm::Module& spnc::MLIRtoLLVMIRConversion::execute() {
     cached = true;
   }
   return *module;
+}
+
+void MLIRtoLLVMIRConversion::optimizeLLVMIR() {
+  llvm::legacy::PassManager modulePM;
+  llvm::legacy::FunctionPassManager funcPM(module.get());
+  llvm::PassManagerBuilder builder;
+  // TODO Allow more fine-grained setting via option.
+  unsigned optLevel = (optimize) ? 3 : 0;
+  unsigned sizeLevel = 0;
+  builder.OptLevel = optLevel;
+  builder.SizeLevel = sizeLevel;
+  builder.Inliner = llvm::createFunctionInliningPass(optLevel, sizeLevel, false);
+  // Currently both kinds of vectorization are always disabled. Either the
+  // vectorization was already performed in MLIR or the user did not request vectorization.
+  builder.LoopVectorize = false;
+  builder.SLPVectorize = false;
+  builder.DisableUnrollLoops = false;
+
+  // Add all coroutine passes to the builder.
+  llvm::addCoroutinePassesToExtensionPoints(builder);
+
+  if (machine.get()) {
+    // Add pass to initialize TTI for this specific target. Otherwise, TTI will
+    // be initialized to NoTTIImpl by default.
+    modulePM.add(createTargetTransformInfoWrapperPass(
+        machine->getTargetIRAnalysis()));
+    funcPM.add(createTargetTransformInfoWrapperPass(
+        machine->getTargetIRAnalysis()));
+  }
+
+  // Populate the pass managers
+  builder.populateModulePassManager(modulePM);
+  builder.populateFunctionPassManager(funcPM);
+
+  // Run the pipelines on the module and the contained functions.
+  funcPM.doInitialization();
+  for (auto& F : *module) {
+    funcPM.run(F);
+  }
+  funcPM.doFinalization();
+  modulePM.run(*module);
 }

--- a/compiler/src/codegen/mlir/conversion/MLIRtoLLVMIRConversion.h
+++ b/compiler/src/codegen/mlir/conversion/MLIRtoLLVMIRConversion.h
@@ -70,6 +70,8 @@ namespace spnc {
 
   private:
 
+    void optimizeLLVMIR();
+
     std::unique_ptr<llvm::Module> module;
 
     bool cached;

--- a/compiler/src/codegen/mlir/conversion/MLIRtoLLVMIRConversion.h
+++ b/compiler/src/codegen/mlir/conversion/MLIRtoLLVMIRConversion.h
@@ -30,7 +30,7 @@ namespace spnc {
     explicit MLIRtoLLVMIRConversion(ActionWithOutput<mlir::ModuleOp>& _input,
                                     std::shared_ptr<mlir::MLIRContext> context,
                                     std::shared_ptr<llvm::TargetMachine> targetMachine,
-                                    bool optimizeOutput = true);
+                                    int optLevel = 3);
 
     llvm::Module& execute() override;
 
@@ -42,8 +42,8 @@ namespace spnc {
     /// \param conv Move source.
     MLIRtoLLVMIRConversion(MLIRtoLLVMIRConversion&& conv) noexcept:
         ActionSingleInput<mlir::ModuleOp, llvm::Module>{conv.input},
-        module{std::move(conv.module)}, cached{conv.cached}, 
-        optimize{conv.optimize}, ctx{std::move(conv.ctx)} {
+        module{std::move(conv.module)}, cached{conv.cached},
+        irOptLevel{conv.irOptLevel}, ctx{std::move(conv.ctx)} {
       conv.cached = false;
     }
 
@@ -56,7 +56,7 @@ namespace spnc {
       this->ctx = std::move(conv.ctx);
       this->cached = conv.cached;
       conv.cached = false;
-      this->optimize = conv.optimize;
+      this->irOptLevel = conv.irOptLevel;
       return *this;
     }
 
@@ -76,7 +76,7 @@ namespace spnc {
 
     bool cached;
 
-    bool optimize;
+    int irOptLevel;
 
     std::shared_ptr<mlir::MLIRContext> ctx;
 

--- a/compiler/src/codegen/mlir/transformation/LoSPNTransformations.cpp
+++ b/compiler/src/codegen/mlir/transformation/LoSPNTransformations.cpp
@@ -12,6 +12,7 @@
 #include "LoSPN/LoSPNOps.h"
 
 void spnc::LoSPNTransformations::initializePassPipeline(mlir::PassManager* pm, mlir::MLIRContext* ctx) {
+  pm->nest<mlir::spn::low::SPNKernel>().addPass(mlir::spn::low::createLoSPNPartitionerPass());
   pm->addPass(mlir::spn::low::createLoSPNBufferizePass());
   pm->addPass(mlir::createCanonicalizerPass());
   pm->nest<mlir::spn::low::SPNKernel>().addPass(mlir::spn::low::createLoSPNCopyRemovalPass());

--- a/compiler/src/codegen/mlir/transformation/LoSPNTransformations.cpp
+++ b/compiler/src/codegen/mlir/transformation/LoSPNTransformations.cpp
@@ -10,9 +10,12 @@
 #include "LoSPN/LoSPNPasses.h"
 #include "mlir/Transforms/Passes.h"
 #include "LoSPN/LoSPNOps.h"
+#include <driver/GlobalOptions.h>
+#include <util/Logging.h>
 
 void spnc::LoSPNTransformations::initializePassPipeline(mlir::PassManager* pm, mlir::MLIRContext* ctx) {
-  pm->nest<mlir::spn::low::SPNKernel>().addPass(mlir::spn::low::createLoSPNPartitionerPass());
+  auto maxTaskSize = spnc::option::maxTaskSize.get(*config);
+  pm->nest<mlir::spn::low::SPNKernel>().addPass(mlir::spn::low::createLoSPNPartitionerPass(maxTaskSize));
   pm->addPass(mlir::spn::low::createLoSPNBufferizePass());
   pm->addPass(mlir::createCanonicalizerPass());
   pm->nest<mlir::spn::low::SPNKernel>().addPass(mlir::spn::low::createLoSPNCopyRemovalPass());

--- a/compiler/src/driver/option/GlobalOptions.cpp
+++ b/compiler/src/driver/option/GlobalOptions.cpp
@@ -23,6 +23,12 @@ EnumOpt spnc::option::compilationTarget{"target",
                                          EnumVal(CUDA, "CUDA")},
                                         {required()}};
 
+Option<int> spnc::option::optLevel{"optLevel", 3};
+
+Option<int> spnc::option::irOptLevel{"irOptLevel"};
+
+Option<int> spnc::option::mcOptLevel{"mcOptLevel"};
+
 Option<int> spnc::option::maxTaskSize{"maxTaskSize", -1};
 
 Option<bool> spnc::option::cpuVectorize{"cpu-vectorize", false};

--- a/compiler/src/driver/option/GlobalOptions.cpp
+++ b/compiler/src/driver/option/GlobalOptions.cpp
@@ -23,6 +23,8 @@ EnumOpt spnc::option::compilationTarget{"target",
                                          EnumVal(CUDA, "CUDA")},
                                         {required()}};
 
+Option<int> spnc::option::maxTaskSize{"maxTaskSize", -1};
+
 Option<bool> spnc::option::cpuVectorize{"cpu-vectorize", false};
 
 using spnc::option::VectorLibrary;

--- a/compiler/src/driver/toolchain/MLIRToolchain.cpp
+++ b/compiler/src/driver/toolchain/MLIRToolchain.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<mlir::ScopedDiagnosticHandler> spnc::MLIRToolchain::setupDiagnos
   });
 }
 
-std::shared_ptr<llvm::TargetMachine> spnc::MLIRToolchain::createTargetMachine(bool cpuVectorize) {
+std::shared_ptr<llvm::TargetMachine> spnc::MLIRToolchain::createTargetMachine(int optLevel) {
   // NOTE: If we wanted to support cross-compilation, we could hook in here to use a different target machine.
 
   llvm::InitializeNativeTarget();
@@ -111,9 +111,23 @@ std::shared_ptr<llvm::TargetMachine> spnc::MLIRToolchain::createTargetMachine(bo
   SPDLOG_INFO("Target machine features: {}", featureList.str());
   SPDLOG_INFO("Target machine CPU physical core count: {}", llvm::sys::getHostNumPhysicalCores());
 
+  llvm::CodeGenOpt::Level cgOptLevel = llvm::CodeGenOpt::Default;
+  switch (optLevel) {
+    case 0: cgOptLevel = llvm::CodeGenOpt::None;
+      break;
+    case 1: cgOptLevel = llvm::CodeGenOpt::Less;
+      break;
+    case 2: cgOptLevel = llvm::CodeGenOpt::Default;
+      break;
+    case 3: cgOptLevel = llvm::CodeGenOpt::Aggressive;
+      break;
+    default: SPNC_FATAL_ERROR("Invalid optimization level {}", optLevel);
+  }
+
   std::shared_ptr<llvm::TargetMachine> machine{target->createTargetMachine(targetTriple,
                                                                            cpu, features.getString(), {},
-                                                                           llvm::Reloc::PIC_)};
+                                                                           llvm::Reloc::PIC_, llvm::None,
+                                                                           cgOptLevel)};
   return machine;
 }
 

--- a/compiler/src/driver/toolchain/MLIRToolchain.cpp
+++ b/compiler/src/driver/toolchain/MLIRToolchain.cpp
@@ -96,20 +96,13 @@ std::shared_ptr<llvm::TargetMachine> spnc::MLIRToolchain::createTargetMachine(bo
   bool initial = true;
   if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
     for (auto& f : hostFeatures) {
-      // Temporary hack: If no vectorization was requested by the user, disable
-      // AVX* target features to avoid the LLVM auto-vectorizer to kick in.
-      // TODO: Replace with a cleaner solution.
-      if (!cpuVectorize && f.first().startswith("avx")) {
-        features.AddFeature(f.first(), false);
-      } else {
-        features.AddFeature(f.first(), f.second);
-        if(f.second){
-          if (!initial) {
-            featureList << ", ";
-          }
-          featureList << f.first().str();
-          initial = false;
+      features.AddFeature(f.first(), f.second);
+      if (f.second) {
+        if (!initial) {
+          featureList << ", ";
         }
+        featureList << f.first().str();
+        initial = false;
       }
     }
   }

--- a/compiler/src/driver/toolchain/MLIRToolchain.h
+++ b/compiler/src/driver/toolchain/MLIRToolchain.h
@@ -26,7 +26,7 @@ namespace spnc {
 
     static std::shared_ptr<mlir::ScopedDiagnosticHandler> setupDiagnosticHandler(mlir::MLIRContext* ctx);
 
-    static std::shared_ptr<llvm::TargetMachine> createTargetMachine(bool cpuVectorize);
+    static std::shared_ptr<llvm::TargetMachine> createTargetMachine(int optLevel);
 
     static llvm::SmallVector<std::string> parseLibrarySearchPaths(const std::string& paths);
 

--- a/mlir/include/Conversion/LoSPNtoCPU/NodePatterns.h
+++ b/mlir/include/Conversion/LoSPNtoCPU/NodePatterns.h
@@ -164,15 +164,25 @@ namespace mlir {
                                     ConversionPatternRewriter& rewriter) const override;
     };
 
+    struct ResolveConvertLog : public OpConversionPattern<low::SPNConvertLog> {
+
+      using OpConversionPattern<low::SPNConvertLog>::OpConversionPattern;
+
+      LogicalResult matchAndRewrite(low::SPNConvertLog op,
+                                    ArrayRef<Value> operands,
+                                    ConversionPatternRewriter& rewriter) const override;
+
+    };
+
     static inline void populateLoSPNtoCPUNodePatterns(OwningRewritePatternList& patterns, MLIRContext* context,
-                                               TypeConverter& typeConverter) {
+                                                      TypeConverter& typeConverter) {
       patterns.insert<BatchReadLowering, BatchWriteLowering, CopyLowering>(typeConverter, context);
       patterns.insert<LogLowering, ReturnLowering, ConstantLowering>(typeConverter, context);
       patterns.insert<MulLowering, AddLowering>(typeConverter, context);
       patterns.insert<MulLogLowering, AddLogLowering>(typeConverter, context);
       patterns.insert<CategoricalLowering, HistogramLowering>(typeConverter, context);
       patterns.insert<GaussianLowering, GaussianLogLowering>(typeConverter, context);
-      patterns.insert<ResolveConvertToVector, ResolveStripLog>(typeConverter, context);
+      patterns.insert<ResolveConvertToVector, ResolveStripLog, ResolveConvertLog>(typeConverter, context);
     }
   }
 }

--- a/mlir/include/Conversion/LoSPNtoCPU/Vectorization/VectorizationPatterns.h
+++ b/mlir/include/Conversion/LoSPNtoCPU/Vectorization/VectorizationPatterns.h
@@ -37,7 +37,7 @@ namespace mlir {
       using OpConversionPattern<low::SPNBatchRead>::OpConversionPattern;
 
       LogicalResult matchAndRewrite(low::SPNBatchRead op,
-                                    ArrayRef<Value> operands,
+                                    ArrayRef <Value> operands,
                                     ConversionPatternRewriter& rewriter) const override;
     };
 
@@ -158,6 +158,15 @@ namespace mlir {
                                     ConversionPatternRewriter& rewriter) const override;
     };
 
+    struct ResolveVectorizedConvertLog : public OpConversionPattern<low::SPNConvertLog> {
+
+      using OpConversionPattern<low::SPNConvertLog>::OpConversionPattern;
+
+      LogicalResult matchAndRewrite(low::SPNConvertLog op,
+                                    ArrayRef <Value> operands,
+                                    ConversionPatternRewriter& rewriter) const override;
+    };
+
     static inline void populateLoSPNCPUVectorizationNodePatterns(OwningRewritePatternList& patterns,
                                                                  MLIRContext* context,
                                                                  TypeConverter& typeConverter) {
@@ -167,7 +176,7 @@ namespace mlir {
       patterns.insert<VectorizeAdd, VectorizeMul, VectorizeLog>(typeConverter, context, 2);
       patterns.insert<VectorizeLogAdd, VectorizeLogMul>(typeConverter, context, 2);
       patterns.insert<VectorizeConstant>(typeConverter, context, 2);
-      patterns.insert<ResolveVectorizedStripLog>(typeConverter, context, 2);
+      patterns.insert<ResolveVectorizedStripLog, ResolveVectorizedConvertLog>(typeConverter, context, 2);
     }
 
   }

--- a/mlir/include/Conversion/LoSPNtoCPU/Vectorization/VectorizationPatterns.h
+++ b/mlir/include/Conversion/LoSPNtoCPU/Vectorization/VectorizationPatterns.h
@@ -32,12 +32,21 @@ namespace mlir {
       patterns.insert<VectorizeBatchTask>(typeConverter, context, 5);
     }
 
-    struct VectorizeBatchRead : public OpConversionPattern<low::SPNBatchRead> {
+    struct Vectorize2DBatchRead : public OpConversionPattern<low::SPNBatchRead> {
 
       using OpConversionPattern<low::SPNBatchRead>::OpConversionPattern;
 
       LogicalResult matchAndRewrite(low::SPNBatchRead op,
                                     ArrayRef<Value> operands,
+                                    ConversionPatternRewriter& rewriter) const override;
+    };
+
+    struct Vectorize1DBatchRead : public OpConversionPattern<low::SPNBatchRead> {
+
+      using OpConversionPattern<low::SPNBatchRead>::OpConversionPattern;
+
+      LogicalResult matchAndRewrite(low::SPNBatchRead op,
+                                    ArrayRef <Value> operands,
                                     ConversionPatternRewriter& rewriter) const override;
     };
 
@@ -150,9 +159,9 @@ namespace mlir {
     };
 
     static inline void populateLoSPNCPUVectorizationNodePatterns(OwningRewritePatternList& patterns,
-                                                          MLIRContext* context,
-                                                          TypeConverter& typeConverter) {
-      patterns.insert<VectorizeBatchRead, VectorizeBatchWrite>(typeConverter, context, 2);
+                                                                 MLIRContext* context,
+                                                                 TypeConverter& typeConverter) {
+      patterns.insert<Vectorize1DBatchRead, Vectorize2DBatchRead, VectorizeBatchWrite>(typeConverter, context, 2);
       patterns.insert<VectorizeCategorical, VectorizeHistogram>(typeConverter, context, 2);
       patterns.insert<VectorizeGaussian, VectorizeLogGaussian>(typeConverter, context, 2);
       patterns.insert<VectorizeAdd, VectorizeMul, VectorizeLog>(typeConverter, context, 2);

--- a/mlir/include/Conversion/LoSPNtoGPU/GPUNodePatterns.h
+++ b/mlir/include/Conversion/LoSPNtoGPU/GPUNodePatterns.h
@@ -161,15 +161,24 @@ namespace mlir {
                                     ConversionPatternRewriter& rewriter) const override;
     };
 
+    struct ResolveConvertLogGPU : public OpConversionPattern<low::SPNConvertLog> {
+
+      using OpConversionPattern<low::SPNConvertLog>::OpConversionPattern;
+
+      LogicalResult matchAndRewrite(low::SPNConvertLog op,
+                                    ArrayRef<Value> operands,
+                                    ConversionPatternRewriter& rewriter) const override;
+    };
+
     static inline void populateLoSPNtoGPUNodePatterns(OwningRewritePatternList& patterns, MLIRContext* context,
-                                               TypeConverter& typeConverter) {
+                                                      TypeConverter& typeConverter) {
       patterns.insert<BatchReadGPULowering, BatchWriteGPULowering, CopyGPULowering>(typeConverter, context);
       patterns.insert<LogGPULowering, ReturnGPULowering, ConstantGPULowering>(typeConverter, context);
       patterns.insert<MulGPULowering, AddGPULowering>(typeConverter, context);
       patterns.insert<MulLogGPULowering, AddLogGPULowering>(typeConverter, context);
       patterns.insert<GaussianGPULowering, GaussianLogGPULowering>(typeConverter, context);
       patterns.insert<CategoricalGPULowering, HistogramGPULowering>(typeConverter, context);
-      patterns.insert<ResolveStripLogGPU>(typeConverter, context);
+      patterns.insert<ResolveStripLogGPU, ResolveConvertLogGPU>(typeConverter, context);
     }
   }
 }

--- a/mlir/include/Dialect/LoSPN/LoSPNOps.h
+++ b/mlir/include/Dialect/LoSPN/LoSPNOps.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/RegionKindInterface.h"
 #include "LoSPN/LoSPNInterfaces.h"
 #include "LoSPN/LoSPNTraits.h"
+#include "LoSPN/LoSPNTypes.h"
 #include "mlir/IR/FunctionSupport.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/BuiltinOps.h"

--- a/mlir/include/Dialect/LoSPN/LoSPNOps.td
+++ b/mlir/include/Dialect/LoSPN/LoSPNOps.td
@@ -226,6 +226,25 @@ def SPNStripLog : LoSPN_Op<"strip_log", [VectorizableOp, DeclareOpInterfaceMetho
     ];
 }
 
+def SPNConvertLog : LoSPN_Op<"convert_log", [VectorizableOp, DeclareOpInterfaceMethods<LoSPNVectorizable>]> {
+    let summary = "Add the log-space property to a value";
+
+    let description = [{
+        Add the log-space property to a value.
+        This operation is only used as a materialization during type
+        conversion and does not generate actual code.
+    }];
+
+    let arguments = (ins LoSPNComputeType:$input);
+
+    let results = (outs LoSPN_LogType:$out);
+
+    let builders = [
+        OpBuilder<(ins "Value":$input)>
+    ];
+
+}
+
 def SPNReturn : LoSPN_Op<"return", [Terminator]> {
 
     let summary = "Return one or multiple results from a Task or Kernel";

--- a/mlir/include/Dialect/LoSPN/LoSPNPasses.h
+++ b/mlir/include/Dialect/LoSPN/LoSPNPasses.h
@@ -20,6 +20,8 @@ namespace mlir {
 
       std::unique_ptr<OperationPass<SPNKernel>> createLoSPNCopyRemovalPass();
 
+      std::unique_ptr<OperationPass<SPNKernel>> createLoSPNPartitionerPass();
+
       /// Instantiate the graph stats collection pass determining SPN statistics like
       /// the number of inner and leaf nodes or min/max/average node level.
       /// \return Pass instance.

--- a/mlir/include/Dialect/LoSPN/LoSPNPasses.h
+++ b/mlir/include/Dialect/LoSPN/LoSPNPasses.h
@@ -20,7 +20,7 @@ namespace mlir {
 
       std::unique_ptr<OperationPass<SPNKernel>> createLoSPNCopyRemovalPass();
 
-      std::unique_ptr<OperationPass<SPNKernel>> createLoSPNPartitionerPass();
+      std::unique_ptr<OperationPass<SPNKernel>> createLoSPNPartitionerPass(int maxTaskSize = -1);
 
       /// Instantiate the graph stats collection pass determining SPN statistics like
       /// the number of inner and leaf nodes or min/max/average node level.

--- a/mlir/include/Dialect/LoSPN/LoSPNPasses.td
+++ b/mlir/include/Dialect/LoSPN/LoSPNPasses.td
@@ -23,4 +23,9 @@ def LoSPNCopyRemoval : Pass<"lospn-copy-removal", "SPNKernel"> {
   let dependentDialects = ["memref::MemRefDialect", "StandardOpsDialect", "scf::SCFDialect"];
 }
 
+def LoSPNTaskPartioning : Pass<"lospn-task-partitioning", "SPNKernel"> {
+  let summary = "Partition LoSPN tasks into multiple tasks";
+  let constructor = "mlir::spn::low::createLoSPNPartitionerPass()";
+}
+
 #endif // MLIR_DIALECT_LoSPN_PASSES

--- a/mlir/include/Dialect/LoSPN/LoSPNPasses.td
+++ b/mlir/include/Dialect/LoSPN/LoSPNPasses.td
@@ -26,6 +26,9 @@ def LoSPNCopyRemoval : Pass<"lospn-copy-removal", "SPNKernel"> {
 def LoSPNTaskPartioning : Pass<"lospn-task-partitioning", "SPNKernel"> {
   let summary = "Partition LoSPN tasks into multiple tasks";
   let constructor = "mlir::spn::low::createLoSPNPartitionerPass()";
+  let options = [
+    Option<"maxTaskSize", "max-task-size", "int", "-1", "Determine the maximum number of operations per task">,
+  ];
 }
 
 #endif // MLIR_DIALECT_LoSPN_PASSES

--- a/mlir/lib/Conversion/LoSPNtoCPU/NodePatterns.cpp
+++ b/mlir/lib/Conversion/LoSPNtoCPU/NodePatterns.cpp
@@ -534,3 +534,15 @@ mlir::LogicalResult mlir::spn::ResolveStripLog::matchAndRewrite(mlir::spn::low::
   rewriter.replaceOp(op, operands[0]);
   return success();
 }
+
+mlir::LogicalResult mlir::spn::ResolveConvertLog::matchAndRewrite(mlir::spn::low::SPNConvertLog op,
+                                                                  llvm::ArrayRef<mlir::Value> operands,
+                                                                  mlir::ConversionPatternRewriter& rewriter) const {
+  assert(operands.size() == 1);
+  auto baseType = typeConverter->convertType(op.getResult().getType());
+  assert(operands[0].getType() == baseType);
+  // Simply replace the conversion by its input operand. All users of the conversion should be
+  // converted subsequently.
+  rewriter.replaceOp(op, operands[0]);
+  return success();
+}

--- a/mlir/lib/Conversion/LoSPNtoCPU/NodePatterns.cpp
+++ b/mlir/lib/Conversion/LoSPNtoCPU/NodePatterns.cpp
@@ -22,9 +22,15 @@ mlir::LogicalResult mlir::spn::BatchReadLowering::matchAndRewrite(mlir::spn::low
   // using the batchIndex and the constant sample index.
   assert(operands.size() == 2 && "Expecting two operands for BatchRead");
   assert(operands[0].getType().isa<MemRefType>());
+  auto memRefType = operands[0].getType().cast<MemRefType>();
   assert(operands[1].getType().isa<IndexType>());
-  auto constSampleIndex = rewriter.create<ConstantOp>(op->getLoc(), rewriter.getIndexAttr(op.sampleIndex()));
-  rewriter.replaceOpWithNewOp<memref::LoadOp>(op, operands[0], ValueRange{operands[1], constSampleIndex});
+  SmallVector<Value> indices;
+  indices.push_back(operands[1]);
+  if (memRefType.getRank() == 2) {
+    auto constSampleIndex = rewriter.create<ConstantOp>(op->getLoc(), rewriter.getIndexAttr(op.sampleIndex()));
+    indices.push_back(constSampleIndex);
+  }
+  rewriter.replaceOpWithNewOp<memref::LoadOp>(op, operands[0], indices);
   return success();
 }
 

--- a/mlir/lib/Conversion/LoSPNtoCPU/StructurePatterns.cpp
+++ b/mlir/lib/Conversion/LoSPNtoCPU/StructurePatterns.cpp
@@ -125,6 +125,9 @@ mlir::LogicalResult mlir::spn::BodyLowering::matchAndRewrite(mlir::spn::low::SPN
     auto arg = std::get<1>(opArg);
     if (arg.getType().isa<low::LogType>()) {
       auto convertLog = rewriter.create<low::SPNConvertLog>(op->getLoc(), operand);
+      if (auto vectorOp = dyn_cast<low::LoSPNVectorizable>(operand.getDefiningOp())) {
+        convertLog.setVectorized(vectorOp.getVectorWidth());
+      }
       argValues.push_back(convertLog);
     } else {
       argValues.push_back(operand);

--- a/mlir/lib/Conversion/LoSPNtoCPU/Vectorization/VectorizeNodePatterns.cpp
+++ b/mlir/lib/Conversion/LoSPNtoCPU/Vectorization/VectorizeNodePatterns.cpp
@@ -65,9 +65,9 @@ namespace {
 
 }
 
-mlir::LogicalResult mlir::spn::VectorizeBatchRead::matchAndRewrite(mlir::spn::low::SPNBatchRead op,
-                                                                   llvm::ArrayRef<mlir::Value> operands,
-                                                                   mlir::ConversionPatternRewriter& rewriter) const {
+mlir::LogicalResult mlir::spn::Vectorize1DBatchRead::matchAndRewrite(mlir::spn::low::SPNBatchRead op,
+                                                                     llvm::ArrayRef<mlir::Value> operands,
+                                                                     mlir::ConversionPatternRewriter& rewriter) const {
   // Replace the vectorized version of a BatchRead with a Gather load from the input memref.
   if (!op.checkVectorized()) {
     return rewriter.notifyMatchFailure(op, "Pattern only matches vectorized BatchRead");
@@ -76,6 +76,34 @@ mlir::LogicalResult mlir::spn::VectorizeBatchRead::matchAndRewrite(mlir::spn::lo
   assert(operands[0].getType().isa<MemRefType>());
   assert(operands[1].getType().isa<IndexType>());
   auto memRef = operands[0].getType().dyn_cast<MemRefType>();
+  assert(memRef.hasRank());
+  if (memRef.getRank() != 1) {
+    // This pattern only handles 1-dimensional memrefs. For 2D memrefs, a more generic implementation
+    // using gather operations is required, see Vectorize2DBatchRead.
+    return rewriter.notifyMatchFailure(op, "Pattern only matches 1D BatchReads");
+  }
+  auto vectorType = VectorType::get({op.vectorFactor()}, memRef.getElementType());
+  rewriter.replaceOpWithNewOp<vector::TransferReadOp>(op, vectorType, operands[0], operands[1]);
+  return success();
+}
+
+mlir::LogicalResult mlir::spn::Vectorize2DBatchRead::matchAndRewrite(mlir::spn::low::SPNBatchRead op,
+                                                                     llvm::ArrayRef<mlir::Value> operands,
+                                                                     mlir::ConversionPatternRewriter& rewriter) const {
+  // Replace the vectorized version of a BatchRead with a Gather load from the input memref.
+  if (!op.checkVectorized()) {
+    return rewriter.notifyMatchFailure(op, "Pattern only matches vectorized BatchRead");
+  }
+  assert(operands.size() == 2);
+  assert(operands[0].getType().isa<MemRefType>());
+  assert(operands[1].getType().isa<IndexType>());
+  auto memRef = operands[0].getType().dyn_cast<MemRefType>();
+  assert(memRef.hasRank());
+  if (memRef.getRank() != 2) {
+    // This pattern only handles 2-dimensional memrefs. For 1D memrefs, a more optimized implementation
+    // using regular (vector) loads instead of gathers is possible (see Vectorize1DBatchRead).
+    return rewriter.notifyMatchFailure(op, "Pattern only matches 2D BatchReads");
+  }
   // Assume that the second dimension (i.e., the number of features per sample is a static dimension).
   assert(!memRef.isDynamicDim(1));
   auto numFeatures = memRef.getDimSize(1);

--- a/mlir/lib/Conversion/LoSPNtoCPU/Vectorization/VectorizeNodePatterns.cpp
+++ b/mlir/lib/Conversion/LoSPNtoCPU/Vectorization/VectorizeNodePatterns.cpp
@@ -637,3 +637,21 @@ mlir::LogicalResult mlir::spn::ResolveVectorizedStripLog::matchAndRewrite(low::S
   rewriter.replaceOp(op, operands[0]);
   return success();
 }
+
+mlir::LogicalResult mlir::spn::ResolveVectorizedConvertLog::matchAndRewrite(mlir::spn::low::SPNConvertLog op,
+                                                                            llvm::ArrayRef<mlir::Value> operands,
+                                                                            mlir::ConversionPatternRewriter& rewriter) const {
+  if (!op.checkVectorized()) {
+    return rewriter.notifyMatchFailure(op, "Pattern only resolves vectorized operation");
+  }
+  assert(operands.size() == 1);
+  auto vectorType = operands[0].getType().dyn_cast<VectorType>();
+  if (!vectorType) {
+    return rewriter.notifyMatchFailure(op, "Expected operand to have vector type");
+  }
+  if (vectorType.getElementType() != op.getResult().getType().cast<low::LogType>().getBaseType()) {
+    return rewriter.notifyMatchFailure(op, "Could not resolve ConvertLog trivially");
+  }
+  rewriter.replaceOp(op, operands[0]);
+  return success();
+}

--- a/mlir/lib/Conversion/LoSPNtoGPU/GPUNodePatterns.cpp
+++ b/mlir/lib/Conversion/LoSPNtoGPU/GPUNodePatterns.cpp
@@ -23,9 +23,15 @@ mlir::LogicalResult mlir::spn::BatchReadGPULowering::matchAndRewrite(mlir::spn::
   // using the batchIndex and the constant sample index.
   assert(operands.size() == 2 && "Expecting two operands for BatchRead");
   assert(operands[0].getType().isa<MemRefType>());
+  auto memRefType = operands[0].getType().cast<MemRefType>();
   assert(operands[1].getType().isa<IndexType>());
-  auto constSampleIndex = rewriter.create<ConstantOp>(op->getLoc(), rewriter.getIndexAttr(op.sampleIndex()));
-  rewriter.replaceOpWithNewOp<memref::LoadOp>(op, operands[0], ValueRange{operands[1], constSampleIndex});
+  SmallVector<Value> indices;
+  indices.push_back(operands[1]);
+  if (memRefType.getRank() == 2) {
+    auto constSampleIndex = rewriter.create<ConstantOp>(op->getLoc(), rewriter.getIndexAttr(op.sampleIndex()));
+    indices.push_back(constSampleIndex);
+  }
+  rewriter.replaceOpWithNewOp<memref::LoadOp>(op, operands[0], indices);
   return success();
 }
 
@@ -491,6 +497,18 @@ mlir::LogicalResult mlir::spn::ResolveStripLogGPU::matchAndRewrite(mlir::spn::lo
   if (operands[0].getType() != op.target()) {
     return rewriter.notifyMatchFailure(op, "Could not resolve StripLog trivially");
   }
+  rewriter.replaceOp(op, operands[0]);
+  return success();
+}
+
+mlir::LogicalResult mlir::spn::ResolveConvertLogGPU::matchAndRewrite(mlir::spn::low::SPNConvertLog op,
+                                                                     llvm::ArrayRef<mlir::Value> operands,
+                                                                     mlir::ConversionPatternRewriter& rewriter) const {
+  assert(operands.size() == 1);
+  auto baseType = typeConverter->convertType(op.getResult().getType());
+  assert(operands[0].getType() == baseType);
+  // Simply replace the conversion by its input operand. All users of the conversion should be
+  // converted subsequently.
   rewriter.replaceOp(op, operands[0]);
   return success();
 }

--- a/mlir/lib/Conversion/LoSPNtoGPU/GPUStructurePatterns.cpp
+++ b/mlir/lib/Conversion/LoSPNtoGPU/GPUStructurePatterns.cpp
@@ -156,6 +156,18 @@ mlir::LogicalResult mlir::spn::BodyGPULowering::matchAndRewrite(mlir::spn::low::
   assert(operands.size() == op.body().front().getNumArguments() &&
       "Expecting the number of operands to match the block arguments");
 
+  SmallVector<Value> argValues;
+  for (auto opArg : llvm::zip(operands, op.body().front().getArguments())) {
+    auto operand = std::get<0>(opArg);
+    auto arg = std::get<1>(opArg);
+    if (arg.getType().isa<low::LogType>()) {
+      auto convertLog = rewriter.create<low::SPNConvertLog>(op->getLoc(), operand);
+      argValues.push_back(convertLog);
+    } else {
+      argValues.push_back(operand);
+    }
+  }
+
   SmallVector<Value, 2> resultValues;
   op.body().front().walk([&](low::SPNYield yield) {
     for (auto res : yield.resultValues()) {
@@ -171,7 +183,7 @@ mlir::LogicalResult mlir::spn::BodyGPULowering::matchAndRewrite(mlir::spn::low::
     }
     rewriter.eraseOp(yield);
   });
-  rewriter.mergeBlockBefore(&op.body().front(), op, operands);
+  rewriter.mergeBlockBefore(&op.body().front(), op, argValues);
   rewriter.replaceOp(op, resultValues);
   return success();
 }

--- a/mlir/lib/Dialect/LoSPN/CMakeLists.txt
+++ b/mlir/lib/Dialect/LoSPN/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_dialect_library(MLIRLoSPN
         Analysis/SPNGraphStatistics.cpp
         Analysis/SPNNodeLevel.cpp
         Partitioning/GraphPartitioner.cpp
+        Partitioning/Heuristic.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/mlir/include/Dialect

--- a/mlir/lib/Dialect/LoSPN/CMakeLists.txt
+++ b/mlir/lib/Dialect/LoSPN/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_dialect_library(MLIRLoSPN
         Passes/LoSPNBufferize.cpp
         Passes/LoSPNCopyRemoval.cpp
         Passes/LoSPNGraphStatsCollection.cpp
+        Passes/LoSPNTaskPartitioner.cpp
         Bufferize/LoSPNBufferizationPatterns.cpp
         Analysis/SPNGraphStatistics.cpp
         Analysis/SPNNodeLevel.cpp

--- a/mlir/lib/Dialect/LoSPN/CMakeLists.txt
+++ b/mlir/lib/Dialect/LoSPN/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_dialect_library(MLIRLoSPN
         Bufferize/LoSPNBufferizationPatterns.cpp
         Analysis/SPNGraphStatistics.cpp
         Analysis/SPNNodeLevel.cpp
+        Partitioning/GraphPartitioner.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/mlir/include/Dialect

--- a/mlir/lib/Dialect/LoSPN/LoSPNOps.cpp
+++ b/mlir/lib/Dialect/LoSPN/LoSPNOps.cpp
@@ -293,6 +293,17 @@ void mlir::spn::low::SPNStripLog::build(::mlir::OpBuilder& odsBuilder,
 }
 
 //===----------------------------------------------------------------------===//
+// SPNConvertLog
+//===----------------------------------------------------------------------===//
+
+void mlir::spn::low::SPNConvertLog::build(::mlir::OpBuilder& odsBuilder,
+                                          ::mlir::OperationState& odsState,
+                                          Value input) {
+  auto logType = mlir::spn::low::LogType::get(input.getType());
+  build(odsBuilder, odsState, logType, input);
+}
+
+//===----------------------------------------------------------------------===//
 // SPNMul
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/LoSPN/LoSPNOps.cpp
+++ b/mlir/lib/Dialect/LoSPN/LoSPNOps.cpp
@@ -94,7 +94,14 @@ namespace mlir {
           return body.emitOpError() << "Incorrect number of block arguments for entry block of Body";
         }
         for (auto argInput : llvm::zip(body.body().front().getArguments(), body.inputs())) {
-          if (std::get<0>(argInput).getType() != std::get<1>(argInput).getType()) {
+          auto argType = std::get<0>(argInput).getType();
+          auto opType = std::get<1>(argInput).getType();
+          // The low::LogType is only used inside SPNBody, so if the block argument is of LogType,
+          // the operand should be of base-type.
+          if (argType.isa<LogType>()) {
+            argType = argType.cast<LogType>().getBaseType();
+          }
+          if (argType != opType) {
             return body.emitOpError() << "Body block argument type does not match Body operand type";
           }
         }
@@ -126,13 +133,20 @@ namespace mlir {
       static mlir::LogicalResult verifyBatchExtract(SPNBatchExtract extract) {
         auto tensor = extract.input().getType().dyn_cast<TensorType>();
         assert(tensor);
-        if (!tensor.hasRank() || tensor.getRank() != 2) {
+        auto nonZeroIndex = extract.sampleIndex() != 0;
+        if (!tensor.hasRank()) {
+          return extract.emitOpError() << "Input tensor should be ranked";
+        }
+        if (tensor.getRank() != 2 && nonZeroIndex) {
           return extract->emitOpError() << "Input tensor should be ranked with two dimensions";
         }
-        if (tensor.isDynamicDim(1)) {
+        if ((tensor.getRank() != 1 && tensor.getRank() != 2) && !nonZeroIndex) {
+          return extract.emitOpError() << "Input tensor should be ranked with one or two dimensions";
+        }
+        if (tensor.getRank() == 2 && tensor.isDynamicDim(1)) {
           return extract->emitOpError() << "Second dimension of input tensor should be static";
         }
-        if (extract.sampleIndex() >= tensor.getDimSize(1)) {
+        if (tensor.getRank() == 2 && extract.sampleIndex() >= tensor.getDimSize(1)) {
           return extract.emitOpError() << "Sample index out-of-bounds for input tensor";
         }
         if (tensor.getElementType() != extract.result().getType()) {
@@ -144,13 +158,20 @@ namespace mlir {
       static mlir::LogicalResult verifyBatchRead(SPNBatchRead read) {
         auto memref = read.batchMem().getType().dyn_cast<MemRefType>();
         assert(memref);
-        if (!memref.hasRank() || memref.getRank() != 2) {
+        auto nonZeroIndex = read.sampleIndex() != 0;
+        if (!memref.hasRank()) {
+          return read.emitOpError() << "Input memref should be ranked";
+        }
+        if (memref.getRank() != 2 && nonZeroIndex) {
           return read->emitOpError() << "Input memref should be ranked with two dimensions";
         }
-        if (memref.isDynamicDim(1)) {
+        if ((memref.getRank() != 1 && memref.getRank() != 2) && !nonZeroIndex) {
+          return read.emitOpError() << "Input memref should be ranked with one or two dimensions";
+        }
+        if (memref.getRank() == 2 && memref.isDynamicDim(1)) {
           return read->emitOpError() << "Second dimension of input memref should be static";
         }
-        if (read.sampleIndex() >= memref.getDimSize(1)) {
+        if (memref.getRank() == 2 && read.sampleIndex() >= memref.getDimSize(1)) {
           return read.emitOpError() << "Sample index out-of-bounds for input memref";
         }
         if (memref.getElementType() != read.result().getType()) {
@@ -221,7 +242,7 @@ mlir::Value mlir::spn::low::SPNTask::getBatchIndex() {
 }
 
 //===----------------------------------------------------------------------===//
-// SPNTask
+// SPNBody
 //===----------------------------------------------------------------------===//
 
 mlir::Block* mlir::spn::low::SPNBody::addEntryBlock() {

--- a/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.cpp
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.cpp
@@ -71,6 +71,8 @@ llvm::SmallVector<std::unique_ptr<mlir::spn::low::Partition>> mlir::spn::low::Gr
     llvm::ArrayRef<Operation*> inNodes,
     llvm::ArrayRef<Value> externalInputs) {
   return initialPartitioning(nodes, inNodes, externalInputs);
+  // TODO: Special handling of constant operations. They can simply be duplicated if necessary and should
+  // never imply an edge crossing partitions.
 }
 
 llvm::SmallVector<std::unique_ptr<mlir::spn::low::Partition>> mlir::spn::low::GraphPartitioner::initialPartitioning(
@@ -87,6 +89,7 @@ llvm::SmallVector<std::unique_ptr<mlir::spn::low::Partition>> mlir::spn::low::Gr
     }
   }
   while (T.size() < nodes.size()) {
+    assert(!S.empty());
     auto cur = S.pop_back_val();
     T.push_back(cur);
     partitioned.insert(cur);

--- a/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.cpp
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.cpp
@@ -1,0 +1,126 @@
+//==============================================================================
+// This file is part of the SPNC project under the Apache License v2.0 by the
+// Embedded Systems and Applications Group, TU Darmstadt.
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// SPDX-License-Identifier: Apache-2.0
+//==============================================================================
+
+#include "GraphPartitioner.h"
+
+using namespace llvm;
+using namespace mlir;
+using namespace mlir::spn::low;
+
+void mlir::spn::low::Partition::addNode(Operation* node) {
+  nodes.insert(node);
+  dirty = true;
+}
+
+void mlir::spn::low::Partition::removeNode(Operation* node) {
+  nodes.erase(node);
+  dirty = true;
+}
+
+bool mlir::spn::low::Partition::contains(Operation* node) {
+  return nodes.contains(node);
+}
+
+llvm::SmallPtrSetImpl<mlir::Operation*>::const_iterator mlir::spn::low::Partition::begin() {
+  return nodes.begin();
+}
+
+llvm::SmallPtrSetImpl<mlir::Operation*>::const_iterator mlir::spn::low::Partition::end() {
+  return nodes.end();
+}
+
+void mlir::spn::low::Partition::computeExternalConnections() {
+  for (auto* n : nodes) {
+    auto usesExt = llvm::any_of(n->getOperands(), [this](Value op) {
+      return !this->nodes.contains(op.getDefiningOp());
+    });
+    if (usesExt) {
+      extIn.push_back(n);
+    }
+    auto providesExt = llvm::any_of(n->getUsers(), [this](Operation* u) {
+      return !this->nodes.contains(u);
+    });
+    if (providesExt) {
+      exOut.push_back(n);
+    }
+  }
+  dirty = false;
+}
+
+llvm::ArrayRef<Operation*> mlir::spn::low::Partition::hasExternalInputs() {
+  if (dirty) {
+    computeExternalConnections();
+  }
+  return extIn;
+}
+
+llvm::ArrayRef<Operation*> mlir::spn::low::Partition::hasExternalOutputs() {
+  if (dirty) {
+    computeExternalConnections();
+  }
+  return exOut;
+}
+
+llvm::SmallVector<std::unique_ptr<mlir::spn::low::Partition>> mlir::spn::low::GraphPartitioner::partitionGraph(
+    llvm::ArrayRef<Operation*> nodes,
+    llvm::ArrayRef<Operation*> inNodes,
+    llvm::ArrayRef<Value> externalInputs) {
+  return initialPartitioning(nodes, inNodes, externalInputs);
+}
+
+llvm::SmallVector<std::unique_ptr<mlir::spn::low::Partition>> mlir::spn::low::GraphPartitioner::initialPartitioning(
+    llvm::ArrayRef<Operation*> nodes,
+    llvm::ArrayRef<Operation*> inNodes,
+    llvm::ArrayRef<Value> externalInputs) const {
+  llvm::SmallPtrSet<Operation*, 32> partitioned;
+  llvm::SmallVector<Operation*> S;
+  llvm::SmallVector<Operation*, 0> T;
+  llvm::SmallPtrSet<Value, 32> external(externalInputs.begin(), externalInputs.end());
+  for (auto I = inNodes.rbegin(); I != inNodes.rend(); ++I) {
+    if (hasInDegreeZero(*I, partitioned, external)) {
+      S.push_back(*I);
+    }
+  }
+  while (T.size() < nodes.size()) {
+    auto cur = S.pop_back_val();
+    T.push_back(cur);
+    partitioned.insert(cur);
+    for (auto r : cur->getResults()) {
+      for (auto* U : r.getUsers()) {
+        if (hasInDegreeZero(U, partitioned, external)) {
+          S.push_back(U);
+        }
+      }
+    }
+  }
+  // TODO Make this configurable
+  unsigned numPartitions = 5;
+  auto nodesPerPartition = llvm::divideNearest(T.size(), numPartitions);
+  llvm::dbgs() << "Nodes per Partition: " << nodesPerPartition << "\n";
+  SmallVector<std::unique_ptr<Partition>> partitioning;
+  unsigned nodeIndex = 0;
+  for (unsigned i = 0; i < numPartitions; ++i) {
+    partitioning.push_back(std::make_unique<Partition>());
+    auto& curPar = partitioning.back();
+    auto maxIndex = nodeIndex + nodesPerPartition;
+    for (; (nodeIndex < maxIndex) && (nodeIndex < T.size()); ++nodeIndex) {
+      curPar->addNode(T[nodeIndex]);
+    }
+  }
+  return partitioning;
+}
+
+bool mlir::spn::low::GraphPartitioner::hasInDegreeZero(Operation* node,
+                                                       llvm::SmallPtrSetImpl<Operation*>& partitioned,
+                                                       llvm::SmallPtrSetImpl<Value>& externalInputs) const {
+  return llvm::all_of(node->getOperands(), [&](Value operand) {
+    return externalInputs.contains(operand)
+        || (operand.getDefiningOp() && partitioned.contains(operand.getDefiningOp()));
+  });
+}
+

--- a/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.h
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.h
@@ -84,13 +84,13 @@ namespace mlir {
         explicit GraphPartitioner(unsigned numberOfPartitions, HeuristicFactory heuristic = nullptr);
 
         Partitioning partitionGraph(llvm::ArrayRef<Operation*> nodes,
-                                    llvm::ArrayRef<Operation*> inNodes,
+                                    llvm::SmallPtrSetImpl<Operation*>& inNodes,
                                     llvm::ArrayRef<Value> externalInputs);
 
       private:
 
         Partitioning initialPartitioning(llvm::ArrayRef<Operation*> nodes,
-                                         llvm::ArrayRef<Operation*> inNodes,
+                                         llvm::SmallPtrSetImpl<Operation*>& inNodes,
                                          llvm::ArrayRef<Value> externalInputs) const;
 
         void refinePartitioning(llvm::ArrayRef<Operation*> allNodes, llvm::ArrayRef<Value> externalInputs,

--- a/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.h
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.h
@@ -21,11 +21,7 @@ namespace mlir {
 
       public:
 
-        Partition(unsigned ID, unsigned maximumSize) : id{ID}, numNodes{0}, maxSize{maximumSize} {
-          // Allow up to 1% or at least one node in slack.
-          unsigned slack = std::max(1u, static_cast<unsigned>(static_cast<double>(maxSize) * 0.01));
-          sizeBoundary = maxSize + slack;
-        };
+        Partition(unsigned ID, unsigned maximumSize) : id{ID}, numNodes{0}, sizeBoundary{maximumSize} {};
 
         void addNode(Operation* node);
 
@@ -75,8 +71,6 @@ namespace mlir {
 
         unsigned numNodes;
 
-        unsigned maxSize;
-
         unsigned sizeBoundary;
 
       };
@@ -85,11 +79,13 @@ namespace mlir {
 
       public:
 
-        explicit GraphPartitioner(unsigned numberOfPartitions, HeuristicFactory heuristic = nullptr);
+        explicit GraphPartitioner(int maxTaskSize, HeuristicFactory heuristic = nullptr);
 
         Partitioning partitionGraph(llvm::ArrayRef<Operation*> nodes,
                                     llvm::SmallPtrSetImpl<Operation*>& inNodes,
                                     llvm::ArrayRef<Value> externalInputs);
+
+        unsigned getMaximumPartitionSize() const;
 
       private:
 
@@ -103,7 +99,7 @@ namespace mlir {
         bool hasInDegreeZero(Operation* node, llvm::SmallPtrSetImpl<Operation*>& partitioned,
                              llvm::SmallPtrSetImpl<Value>& externalInputs) const;
 
-        unsigned numPartitions;
+        int maxPartitionSize;
 
         HeuristicFactory factory;
 

--- a/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.h
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.h
@@ -1,0 +1,77 @@
+//==============================================================================
+// This file is part of the SPNC project under the Apache License v2.0 by the
+// Embedded Systems and Applications Group, TU Darmstadt.
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// SPDX-License-Identifier: Apache-2.0
+//==============================================================================
+
+#ifndef SPNC_MLIR_LIB_DIALECT_LOSPN_PARTITIONING_GRAPHPARTITIONER_H
+#define SPNC_MLIR_LIB_DIALECT_LOSPN_PARTITIONING_GRAPHPARTITIONER_H
+
+#include "LoSPN/LoSPNOps.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+namespace mlir {
+  namespace spn {
+    namespace low {
+
+      class Partition {
+
+      public:
+
+        void addNode(Operation* node);
+
+        void removeNode(Operation* node);
+
+        bool contains(Operation* node);
+
+        SmallPtrSetImpl<Operation*>::const_iterator begin();
+
+        SmallPtrSetImpl<Operation*>::const_iterator end();
+
+        llvm::ArrayRef<Operation*> hasExternalInputs();
+
+        llvm::ArrayRef<Operation*> hasExternalOutputs();
+
+      private:
+
+        llvm::SmallPtrSet<Operation*, 32> nodes;
+
+        bool dirty = false;
+
+        llvm::SmallVector<Operation*> extIn;
+
+        llvm::SmallVector<Operation*> exOut;
+
+        void computeExternalConnections();
+
+      };
+
+      class GraphPartitioner {
+
+      public:
+
+        // TODO
+        explicit GraphPartitioner() = default;
+
+        SmallVector<std::unique_ptr<Partition>> partitionGraph(llvm::ArrayRef<Operation*> nodes,
+                                                               llvm::ArrayRef<Operation*> inNodes,
+                                                               llvm::ArrayRef<Value> externalInputs);
+
+      private:
+
+        SmallVector<std::unique_ptr<Partition>> initialPartitioning(llvm::ArrayRef<Operation*> nodes,
+                                                                    llvm::ArrayRef<Operation*> inNodes,
+                                                                    llvm::ArrayRef<Value> externalInputs) const;
+
+        bool hasInDegreeZero(Operation* node, llvm::SmallPtrSetImpl<Operation*>& partitioned,
+                             llvm::SmallPtrSetImpl<Value>& externalInputs) const;
+
+      };
+
+    }
+  }
+}
+
+#endif //SPNC_MLIR_LIB_DIALECT_LOSPN_PARTITIONING_GRAPHPARTITIONER_H

--- a/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.h
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/GraphPartitioner.h
@@ -53,6 +53,10 @@ namespace mlir {
           return numNodes < sizeBoundary;
         }
 
+        void invalidateExternal() {
+          dirty = true;
+        }
+
         void dump() const;
 
       private:

--- a/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.cpp
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.cpp
@@ -47,6 +47,7 @@ Partition* Heuristic::getPartitionByID(unsigned int ID) {
 void Heuristic::moveNode(Operation* node, Partition* from, Partition* to) {
   from->removeNode(node);
   to->addNode(node);
+  partitionMap[node] = to->ID();
 }
 
 void SimpleMoveHeuristic::refinePartitioning() {
@@ -102,7 +103,7 @@ void SimpleMoveHeuristic::refinePartitioning() {
     }
 
     // Downward direction
-    llvm::Optional<int> downwardCost;
+    llvm::Optional<int> downwardCost = llvm::None;
     if (i != 0) {
       // Calculate the positive gain: All edges from operands of 'node' that are in partition i-1
       // will become internal edges.

--- a/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.cpp
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.cpp
@@ -1,0 +1,180 @@
+//==============================================================================
+// This file is part of the SPNC project under the Apache License v2.0 by the
+// Embedded Systems and Applications Group, TU Darmstadt.
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// SPDX-License-Identifier: Apache-2.0
+//==============================================================================
+
+#include "Heuristic.h"
+#include "GraphPartitioner.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace mlir;
+using namespace mlir::spn::low;
+
+Heuristic::Heuristic(llvm::ArrayRef<Operation*> allNodes,
+                     llvm::ArrayRef<Value> externalInputs,
+                     Partitioning* allPartitions) : nodes(allNodes.begin(), allNodes.end()),
+                                                    external(externalInputs.begin(), externalInputs.end()),
+                                                    partitions(allPartitions) {
+  for (auto& p : *partitions) {
+    auto id = p->ID();
+    maxPartition = std::max(maxPartition, id);
+    for (auto* n : *p) {
+      partitionMap[n] = id;
+    }
+  }
+  llvm::dbgs() << partitionMap.size() << "\n";
+}
+
+unsigned int Heuristic::getPartitionIDForNode(Operation* node) {
+  assert(node);
+  assert(partitionMap.count(node) && "Node must be contained in map");
+  return partitionMap[node];
+}
+
+Partition* Heuristic::getPartitionForNode(Operation* node) {
+  auto partitionID = getPartitionIDForNode(node);
+  return partitions->at(partitionID).get();
+}
+
+Partition* Heuristic::getPartitionByID(unsigned int ID) {
+  assert(ID < partitions->size());
+  return partitions->at(ID).get();
+}
+
+void Heuristic::moveNode(Operation* node, Partition* from, Partition* to) {
+  from->removeNode(node);
+  to->addNode(node);
+}
+
+void SimpleMoveHeuristic::refinePartitioning() {
+  llvm::SmallPtrSet<Value, 10> externalIn(external.begin(), external.end());
+
+  for (auto* node : nodes) {
+
+    // Do not move constant operations, they can be internalized by duplication.
+    if (node->hasTrait<OpTrait::ConstantLike>()) {
+      continue;
+    }
+
+    // Each node can either be moved from partition i 'upward' to partition i+1
+    // or 'downward' to partition i-1.
+    auto i = getPartitionIDForNode(node);
+
+    // Upward direction
+    llvm::Optional<int> upwardCost = llvm::None;
+    if (i != maxPartition) {
+      // Calculate the positive gain: All edges to users of 'node' that are in partition i+1
+      // will become internal edges.
+      int gain = 0;
+      bool legal = true;
+      for (auto* U : node->getUsers()) {
+        // TODO Handle SPNYield
+        if (isa<SPNYield>(U)) {
+          continue;
+        }
+        auto partitionID = getPartitionIDForNode(U);
+        if (partitionID == i + 1) {
+          // Although there might be multiple users in the upward partition, the overall gain for all
+          // of them combined is only 1, as the result of the node only needs to be stored/loaded to/from
+          // memory once for all users in one partition.
+          gain = 1;
+        }
+        if (partitionID == i) {
+          // If we have an user in the same partition, it's not legal to move the node upwards.
+          legal = false;
+          break;
+        }
+      }
+      // Calculate the negative gain. All edges from operands of 'node' that are in partition i
+      // will become external edges.
+      for (auto operand : node->getOperands()) {
+        // TODO Handle constants
+        if (!externalIn.contains(operand) && getPartitionIDForNode(operand.getDefiningOp()) == i) {
+          --gain;
+        }
+      }
+      if (legal) {
+        upwardCost = gain;
+      }
+    }
+
+    // Downward direction
+    llvm::Optional<int> downwardCost;
+    if (i != 0) {
+      // Calculate the positive gain: All edges from operands of 'node' that are in partition i-1
+      // will become internal edges.
+      int gain = 0;
+      bool legal = true;
+      for (auto operand : node->getOperands()) {
+        if (externalIn.contains(operand)) {
+          continue;
+        }
+        auto partitionID = getPartitionIDForNode(operand.getDefiningOp());
+        if (partitionID == i - 1) {
+          ++gain;
+        }
+        if (partitionID == i) {
+          // If we have an operand in the same partition, it's illegal to push the node downwards.
+          legal = false;
+          break;
+        }
+      }
+      // Calculate the negative gain: All edges to users of 'node' that are in partition i
+      // will become external edges. As the result of the operation only needs to be
+      // stored/loaded to/from memory once for all users, the gain is only decremented by 1
+      // if there's any user.
+      auto usedInSame = llvm::any_of(node->getUsers(), [this, i](Operation* U) {
+        return !isa<SPNYield>(U) && getPartitionIDForNode(U) == i;
+      });
+      if (usedInSame) {
+        --gain;
+      }
+
+      if (legal) {
+        downwardCost = gain;
+      }
+    }
+
+    int upwardGain = upwardCost.getValueOr(INT32_MIN);
+    int downwardGain = downwardCost.getValueOr(INT32_MIN);
+    auto partition = getPartitionForNode(node);
+    if (upwardGain == downwardGain && upwardGain >= 0) {
+      // We have a tie, with positive gain in both cases.
+      // Try to resolve the tie based on size of the partitions.
+      auto* upwardPart = getPartitionByID(i + 1);
+      auto* downwardPart = getPartitionByID(i - 1);
+      auto upwardDifference = static_cast<int>(partition->size()) - static_cast<int>(upwardPart->size());
+      auto downwardDifference = static_cast<int>(partition->size()) - static_cast<int>(downwardPart->size());
+      if (upwardDifference > downwardDifference && (upwardDifference > 0 || upwardGain > 0)
+          && upwardPart->canAccept()) {
+        moveNode(node, partition, upwardPart);
+      } else if ((downwardDifference > 0 || downwardGain > 0) && downwardPart->canAccept()) {
+        moveNode(node, partition, downwardPart);
+      }
+    }
+    if (upwardGain > downwardGain && upwardGain >= 0) {
+      auto* upwardPart = getPartitionByID(i + 1);
+      auto upwardDifference = static_cast<int>(partition->size()) - static_cast<int>(upwardPart->size());
+      if ((upwardGain > 0 || upwardDifference > 0) && upwardPart->canAccept()) {
+        // Operations are moved in two cases:
+        // (1) We have a positive gain (i.e. less edges crossing partitions)
+        // (2) We can balance the partitions (i.e., partition i is larger than partition i+1).
+        moveNode(node, partition, upwardPart);
+      }
+    }
+    if (downwardGain > upwardGain && downwardGain >= 0) {
+      auto* downwardPart = getPartitionByID(i - 1);
+      auto downwardDifference = static_cast<int>(partition->size()) - static_cast<int>(downwardPart->size());
+      if ((downwardGain > 0 || downwardDifference > 0) && downwardPart->canAccept()) {
+        // Operations are moved in two cases:
+        // (1) We have a positive gain (i.e. less edges crossing partitions)
+        // (2) We can balance the partitions (i.e., partition i is larger than partition i+1).
+        moveNode(node, partition, downwardPart);
+      }
+    }
+  }
+
+}

--- a/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.cpp
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.cpp
@@ -25,7 +25,6 @@ Heuristic::Heuristic(llvm::ArrayRef<Operation*> allNodes,
       partitionMap[n] = id;
     }
   }
-  llvm::dbgs() << partitionMap.size() << "\n";
 }
 
 unsigned int Heuristic::getPartitionIDForNode(Operation* node) {

--- a/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.h
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.h
@@ -1,0 +1,84 @@
+//==============================================================================
+// This file is part of the SPNC project under the Apache License v2.0 by the
+// Embedded Systems and Applications Group, TU Darmstadt.
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// SPDX-License-Identifier: Apache-2.0
+//==============================================================================
+
+#ifndef SPNC_MLIR_LIB_DIALECT_LOSPN_PARTITIONING_HEURISTIC_H
+#define SPNC_MLIR_LIB_DIALECT_LOSPN_PARTITIONING_HEURISTIC_H
+
+#include <memory>
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace mlir {
+  namespace spn {
+    namespace low {
+
+      // Forward declaration to avoid circular header dependency
+      class Partition;
+
+      using PartitionRef = std::unique_ptr<Partition>;
+
+      using Partitioning = std::vector<PartitionRef>;
+
+      class Heuristic {
+
+      public:
+
+        Heuristic(llvm::ArrayRef<Operation*> allNodes, llvm::ArrayRef<Value> externalInputs,
+                  Partitioning* allPartitions);
+
+        virtual ~Heuristic() = default;
+
+        virtual void refinePartitioning() = 0;
+
+      protected:
+
+        llvm::SmallVector<Operation*> nodes;
+
+        llvm::SmallVector<Value> external;
+
+        Partitioning* partitions;
+
+        unsigned maxPartition = 0;
+
+        llvm::DenseMap<Operation*, unsigned> partitionMap;
+
+        Partition* getPartitionForNode(Operation* node);
+
+        unsigned getPartitionIDForNode(Operation* node);
+
+        Partition* getPartitionByID(unsigned ID);
+
+        void moveNode(Operation* node, Partition* from, Partition* to);
+
+      };
+
+      using HeuristicFactory =
+      std::function<std::unique_ptr<Heuristic>(llvm::ArrayRef<Operation*>, llvm::ArrayRef<Value>,
+                                               Partitioning*)>;
+
+      class SimpleMoveHeuristic : public Heuristic {
+
+      public:
+
+        using Heuristic::Heuristic;
+
+        void refinePartitioning() override;
+
+        static std::unique_ptr<SimpleMoveHeuristic> create(llvm::ArrayRef<Operation*> allNodes,
+                                                           llvm::ArrayRef<Value> externalInputs,
+                                                           Partitioning* allPartitions) {
+          return std::make_unique<SimpleMoveHeuristic>(allNodes, externalInputs, allPartitions);
+        }
+
+      };
+
+    }
+  }
+}
+
+#endif //SPNC_MLIR_LIB_DIALECT_LOSPN_PARTITIONING_HEURISTIC_H

--- a/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.h
+++ b/mlir/lib/Dialect/LoSPN/Partitioning/Heuristic.h
@@ -55,6 +55,8 @@ namespace mlir {
 
         void moveNode(Operation* node, Partition* from, Partition* to);
 
+        bool isConstant(Operation* op) const;
+
       };
 
       using HeuristicFactory =

--- a/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
+++ b/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
@@ -33,7 +33,7 @@ namespace mlir {
           // All operations in the Task relevant for partitioning
           SmallVector<Operation*> nodes;
           // All operations with no internal operands (in-degree 0)
-          SmallVector<Operation*> inNodes;
+          SmallPtrSet<Operation*, 10> inNodes;
           // All inputs considered external for the partitioning.
           SmallVector<Value> external;
           // Mapping from Value to a Tensor + index, either from an external
@@ -72,7 +72,7 @@ namespace mlir {
                 inputs[blockArg] = InputInfo{externalTensor, collect.sampleIndex()};
                 // All users of the entry block args potentially do not have outside operands.
                 for (auto* U : blockArg.getUsers()) {
-                  inNodes.push_back(U);
+                  inNodes.insert(U);
                 }
               }
               body.body().walk([&](Operation* op) {
@@ -85,7 +85,7 @@ namespace mlir {
                   if (op->hasTrait<OpTrait::ConstantLike>()) {
                     // Constant operations do not have an operand, so they
                     // should be used as seeds for the initial partitioning, too.
-                    inNodes.push_back(op);
+                    inNodes.insert(op);
                   }
                 }
               });

--- a/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
+++ b/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
@@ -43,6 +43,7 @@ namespace mlir {
           // input of this task or internally from another partition.
           InputMap inputs;
           SmallVector<Value> taskResults;
+          unsigned numNodes = 0;
           {
             // Map arguments of the entry block to external inputs of the task.
             llvm::DenseMap<mlir::BlockArgument, mlir::Value> externalTensors;
@@ -91,12 +92,14 @@ namespace mlir {
                     // Constant operations do not have an operand, so they
                     // should be used as seeds for the initial partitioning, too.
                     inNodes.insert(op);
+                  } else {
+                    ++numNodes;
                   }
                 }
               });
             });
           }
-          if (nodes.size() <= partitioner.getMaximumPartitionSize()) {
+          if (numNodes <= partitioner.getMaximumPartitionSize()) {
             // Do not partition a task if it is already smaller than the maximum size.
             return mlir::failure();
           }

--- a/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
+++ b/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
@@ -82,7 +82,7 @@ namespace mlir {
                   }
                 } else {
                   nodes.push_back(op);
-                  if (isa<SPNConstant>(op)) {
+                  if (op->hasTrait<OpTrait::ConstantLike>()) {
                     // Constant operations do not have an operand, so they
                     // should be used as seeds for the initial partitioning, too.
                     inNodes.push_back(op);

--- a/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
+++ b/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
@@ -1,0 +1,287 @@
+//==============================================================================
+// This file is part of the SPNC project under the Apache License v2.0 by the
+// Embedded Systems and Applications Group, TU Darmstadt.
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// SPDX-License-Identifier: Apache-2.0
+//==============================================================================
+
+#include <mlir/Rewrite/FrozenRewritePatternSet.h>
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/Passes.h"
+#include "LoSPNPassDetails.h"
+#include "LoSPN/LoSPNPasses.h"
+#include "LoSPN/LoSPNOps.h"
+#include "LoSPN/LoSPNTypes.h"
+#include "../Partitioning/GraphPartitioner.h"
+
+namespace mlir {
+  namespace spn {
+    namespace low {
+
+      class PartitionTask : public OpRewritePattern<low::SPNTask> {
+
+      public:
+        PartitionTask(MLIRContext* ctx, GraphPartitioner& part) :
+            OpRewritePattern<low::SPNTask>(ctx, 1), partitioner(part) {}
+
+        LogicalResult matchAndRewrite(SPNTask op, PatternRewriter& rewriter) const override {
+          // All operations in the Task relevant for partitioning
+          SmallVector<Operation*> nodes;
+          // All operations with no internal operands (in-degree 0)
+          SmallVector<Operation*> inNodes;
+          // All inputs considered external for the partitioning.
+          SmallVector<Value> external;
+          // Mapping from Value to a Tensor + index, either from an external
+          // input of this task or internally from another partition.
+          InputMap inputs;
+          SmallVector<Value> taskResults;
+          {
+            // Map arguments of the entry block to external inputs of the task.
+            llvm::DenseMap<mlir::BlockArgument, mlir::Value> externalTensors;
+            unsigned tensorIndex = 0;
+            bool initial = true;
+            for (auto& blockArg : op.getBody()->getArguments()) {
+              if (initial) {
+                // The first block argument is the batch index, skip it.
+                initial = false;
+                continue;
+              }
+              externalTensors[blockArg] = op->getOperand(tensorIndex++);
+            }
+            op->walk([&](SPNBody body) {
+              unsigned inIndex = 0;
+              for (auto blockArg : body.getBody()->getArguments()) {
+                external.push_back(blockArg);
+                // Detect the BatchExtract producing this block arg:
+                auto bodyOp = body->getOperand(inIndex++);
+                assert(isa<SPNBatchExtract>(bodyOp.getDefiningOp()));
+                auto collect = cast<SPNBatchExtract>(bodyOp.getDefiningOp());
+                assert(collect.input().isa<BlockArgument>());
+                // Get the input tensor of the BatchExtract
+                auto tensorArg = collect.input();
+                // Match the input tensor of the BatchExtract
+                // (which should be a block argument of the Task's entry block)
+                // to the external operand of the task.
+                assert(externalTensors.count(tensorArg.cast<BlockArgument>()));
+                auto externalTensor = externalTensors[tensorArg.cast<BlockArgument>()];
+                inputs[blockArg] = InputInfo{externalTensor, collect.sampleIndex()};
+                // All users of the entry block args potentially do not have outside operands.
+                for (auto* U : blockArg.getUsers()) {
+                  inNodes.push_back(U);
+                }
+              }
+              body.body().walk([&](Operation* op) {
+                if (isa<SPNYield>(op)) {
+                  for (auto resVal : op->getOperands()) {
+                    taskResults.push_back(resVal);
+                  }
+                } else {
+                  nodes.push_back(op);
+                }
+              });
+            });
+          }
+          if (nodes.size() < 8) {
+            return mlir::failure();
+          }
+          // Perform the actual partitioning.
+          auto partition = partitioner.partitionGraph(nodes, inNodes, external);
+          SmallVector<PartitionInfo> partitions;
+          unsigned index = 0;
+          for (auto& p : partition) {
+            llvm::dbgs() << "Partition " << index << ":\n";
+            for (auto o : *p) {
+              o->dump();
+            }
+            ++index;
+            partitions.push_back(PartitionInfo{p.get(), false});
+          }
+          for (auto& p : partitions) {
+            createTaskForPartition(p, rewriter, op.getLoc(), op.batchSize(), inputs, partitions);
+          }
+          SmallVector<Value> newResults;
+          for (auto res : taskResults) {
+            newResults.push_back(inputs.lookup(res).first);
+          }
+          //assert(false);
+          rewriter.replaceOp(op, newResults);
+          return mlir::success();
+        }
+
+      private:
+
+        using InputInfo = std::pair<mlir::Value, unsigned>;
+
+        using InputMap = llvm::DenseMap<mlir::Value, InputInfo>;
+
+        using PartitionInfo = std::pair<Partition*, bool>;
+
+        void createTaskForPartition(PartitionInfo partition, PatternRewriter& rewriter, Location loc,
+                                    unsigned batchSize,
+                                    InputMap& inputs, llvm::ArrayRef<PartitionInfo> partitions) const {
+          // First, collect all input values coming from either outside arguments of the original task or
+          // from other partitions.
+          InputMap nonPartitionInputs;
+          llvm::MapVector<Value, unsigned> inputArgs;
+          unsigned inputArgIndex = 1;
+          for (auto* o : partition.first->hasExternalInputs()) {
+            for (auto operand : o->getOperands()) {
+              if (!partition.first->contains(operand.getDefiningOp())) {
+                if (!inputs.count(operand)) {
+                  // First, check the map for pre-existing entries.
+                  // If no mapping is present, the input must be produced by another partition.
+                  auto otherPartition = findPartition(operand, partitions);
+                  // Convert the partition producing the input to a task first.
+                  createTaskForPartition(otherPartition, rewriter, loc, batchSize, inputs, partitions);
+                  // Input should be present after conversion.
+                  assert(inputs.count(operand));
+                }
+                auto inputInfo = inputs[operand];
+                nonPartitionInputs[operand] = inputInfo;
+                if (!inputArgs.count(inputInfo.first)) {
+                  inputArgs[inputInfo.first] = inputArgIndex++;
+                }
+              }
+            }
+          }
+          // Collect information about which values this task will provide to other partitions.
+          SmallVector<Value> nonPartitionOutputs;
+          SmallVector<Type> resultTypes;
+          SmallVector<Type> bodyResults;
+          for (auto* o : partition.first->hasExternalOutputs()) {
+            for (auto result : o->getResults()) {
+              // Only add to nonPartitionOutputs if there's at least one user outside of the partition.
+              for (auto* U : result.getUsers()) {
+                if (!partition.first->contains(U)) {
+                  nonPartitionOutputs.push_back(result);
+                  auto resultType = performTypeConversion(result.getType());
+                  resultTypes.push_back(RankedTensorType::get({-1}, resultType));
+                  bodyResults.push_back(resultType);
+                  break;
+                }
+              }
+            }
+          }
+          SmallVector<Value> taskInputs;
+          for (auto& in : inputArgs) {
+            taskInputs.push_back(in.first);
+          }
+          auto task = rewriter.create<SPNTask>(loc, resultTypes, taskInputs, batchSize);
+          auto restore = rewriter.saveInsertionPoint();
+          auto taskBlock = task.addEntryBlock();
+          rewriter.setInsertionPointToStart(taskBlock);
+          llvm::DenseMap<Value, unsigned> inputIndices;
+          SmallVector<Value> bodyInputs;
+          unsigned bodyArgIndex = 0;
+          bool hasLogType[nonPartitionInputs.size()];
+          for (auto& in : nonPartitionInputs) {
+            auto value = in.getFirst();
+            auto inputInfo = in.getSecond();
+            auto index = inputArgs[inputInfo.first];
+            hasLogType[bodyArgIndex] = value.getType().isa<low::LogType>();
+            inputIndices[value] = bodyArgIndex++;
+            auto extract = rewriter.create<SPNBatchExtract>(loc,
+                                                            performTypeConversion(value.getType()),
+                                                            taskBlock->getArgument(index),
+                                                            task.getBatchIndex(), inputInfo.second);
+            bodyInputs.push_back(extract);
+          }
+          auto body = rewriter.create<SPNBody>(loc, bodyResults, bodyInputs);
+          auto restoreBody = rewriter.saveInsertionPoint();
+          auto bodyBlock = rewriter.createBlock(&body.body());
+          auto index = 0;
+          for (auto& bodyIn : bodyInputs) {
+            if (hasLogType[index++]) {
+              bodyBlock->addArgument(low::LogType::get(bodyIn.getType()));
+            } else {
+              bodyBlock->addArgument(bodyIn.getType());
+            }
+          }
+          BlockAndValueMapping mapper;
+          for (auto remapped : inputIndices) {
+            mapper.map(remapped.getFirst(), bodyBlock->getArgument(remapped.second));
+          }
+          for (auto operation : *partition.first) {
+            copyOperation(operation, rewriter, mapper);
+          }
+          SmallVector<Value> bodyYields;
+          unsigned resultIndex = 0;
+          for (auto retVal : nonPartitionOutputs) {
+            bodyYields.push_back(mapper.lookupOrNull(retVal));
+            inputs[retVal] = InputInfo{task->getResult(resultIndex++), 0};
+          }
+          rewriter.create<SPNYield>(loc, bodyYields);
+          rewriter.restoreInsertionPoint(restoreBody);
+          SmallVector<Value> taskReturns;
+          for (auto r : body.getResults()) {
+            auto rType = RankedTensorType::get({-1}, r.getType());
+            auto collect = rewriter.create<SPNBatchCollect>(loc, rType, r, task.getBatchIndex());
+            taskReturns.push_back(collect.getResult(0));
+          }
+          rewriter.create<SPNReturn>(loc, taskReturns);
+          task.dump();
+          rewriter.restoreInsertionPoint(restore);
+        }
+
+        void copyOperation(Operation* op, PatternRewriter& rewriter, BlockAndValueMapping& mapper) const {
+          for (auto operand : op->getOperands()) {
+            if (!mapper.contains(operand)) {
+              // Copy definition first to ensure legality of def-use-chains
+              copyOperation(operand.getDefiningOp(), rewriter, mapper);
+            }
+            (void) rewriter.clone(*op, mapper);
+          }
+        }
+
+        PartitionInfo findPartition(Value input, llvm::ArrayRef<PartitionInfo> partitions) const {
+          for (auto& p : partitions) {
+            if (p.second) {
+              // This partition has already been converted and all outputs should be present in the map.
+              continue;
+            }
+            for (auto* o : p.first->hasExternalOutputs()) {
+              if (o == input.getDefiningOp()) {
+                return p;
+              }
+            }
+          }
+          return PartitionInfo{nullptr, false};
+        }
+
+        Type performTypeConversion(Type type) const {
+          if (type.isa<low::LogType>()) {
+            return type.cast<low::LogType>().getBaseType();
+          }
+          return type;
+        }
+
+        GraphPartitioner& partitioner;
+
+      };
+
+      struct LoSPNTaskPartitioner : LoSPNTaskPartioningBase<LoSPNTaskPartitioner> {
+
+      protected:
+
+        void runOnOperation() override {
+          GraphPartitioner partitioner{};
+          RewritePatternSet patterns(getOperation()->getContext());
+          patterns.insert<PartitionTask>(getOperation()->getContext(), partitioner);
+          mlir::FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+          applyPatternsAndFoldGreedily(getOperation(), frozenPatterns);
+        }
+
+      };
+
+    }
+  }
+}
+
+std::unique_ptr<mlir::OperationPass<mlir::spn::low::SPNKernel>> mlir::spn::low::createLoSPNPartitionerPass() {
+  return std::make_unique<LoSPNTaskPartitioner>();
+}

--- a/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
+++ b/mlir/lib/Dialect/LoSPN/Passes/LoSPNTaskPartitioner.cpp
@@ -7,6 +7,7 @@
 //==============================================================================
 
 #include <mlir/Rewrite/FrozenRewritePatternSet.h>
+#include <llvm/ADT/IndexedMap.h>
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/IR/BlockAndValueMapping.h"
@@ -205,7 +206,8 @@ namespace mlir {
           llvm::DenseMap<Value, unsigned> inputIndices;
           SmallVector<Value> bodyInputs;
           unsigned bodyArgIndex = 0;
-          bool hasLogType[nonPartitionInputs.size()];
+          llvm::IndexedMap<bool> hasLogType;
+          hasLogType.grow(nonPartitionInputs.size());
           for (auto& in : nonPartitionInputs) {
             auto value = in.getFirst();
             auto inputInfo = in.getSecond();

--- a/python-interface/test/cpu/test_cpu_categorical.py
+++ b/python-interface/test/cpu/test_cpu_categorical.py
@@ -35,10 +35,6 @@ def test_cpu_categorical():
         np.random.randint(3, size=30),
     )).astype("int32")
 
-    if not CPUCompiler.isVectorizationSupported():
-        print("Test not supported by the compiler installation")
-        return 0
-
     # Execute the compiled Kernel.
     results = CPUCompiler(computeInLogSpace=False, vectorize=False).log_likelihood(p, inputs, supportMarginal=False, batchSize=10)
 

--- a/python-interface/test/cpu/test_cpu_gaussian.py
+++ b/python-interface/test/cpu/test_cpu_gaussian.py
@@ -41,10 +41,6 @@ def test_cpu_gaussian():
                             np.random.normal(0.58, 0.9, 30),
                             np.random.normal(0.14, 0.2, 30))).astype("float64")
 
-    if not CPUCompiler.isVectorizationSupported():
-        print("Test not supported by the compiler installation")
-        return 0
-
     # Execute the compiled Kernel.
     results = CPUCompiler(computeInLogSpace=False, vectorize=False).log_likelihood(p, inputs, supportMarginal=False, batchSize=10)
 

--- a/python-interface/test/cpu/test_cpu_histogram.py
+++ b/python-interface/test/cpu/test_cpu_histogram.py
@@ -36,7 +36,9 @@ def test_cpu_histogram():
         return 0
 
     # Execute the compiled Kernel.
-    results = CPUCompiler(computeInLogSpace=False, vectorize=False).log_likelihood(spn, inputs, supportMarginal=False, batchSize=10)
+    results = CPUCompiler(computeInLogSpace=False, vectorize=False, maxTaskSize=5).log_likelihood(spn, inputs,
+                                                                                                  supportMarginal=False,
+                                                                                                  batchSize=10)
 
     # Compute the reference results using the inference from SPFlow.
     reference = log_likelihood(spn, inputs)

--- a/python-interface/test/cpu/test_graph_partitioning.py
+++ b/python-interface/test/cpu/test_graph_partitioning.py
@@ -32,9 +32,9 @@ def test_cpu_histogram():
     )).astype("float64")
 
     # Execute the compiled Kernel.
-    results = CPUCompiler(computeInLogSpace=False, vectorize=False).log_likelihood(spn, inputs,
-                                                                                   supportMarginal=False,
-                                                                                   batchSize=10)
+    results = CPUCompiler(computeInLogSpace=False, vectorize=False, maxTaskSize=5).log_likelihood(spn, inputs,
+                                                                                                  supportMarginal=False,
+                                                                                                  batchSize=10)
 
     # Compute the reference results using the inference from SPFlow.
     reference = log_likelihood(spn, inputs)
@@ -43,7 +43,7 @@ def test_cpu_histogram():
     # Check the computation results against the reference
     # Check in normal space if log-results are not very close to each other.
     assert np.all(np.isclose(results, reference)) or np.all(np.isclose(np.exp(results), np.exp(reference)))
-    
+
 
 if __name__ == "__main__":
     test_cpu_histogram()


### PR DESCRIPTION
Break large LoSPN tasks into multiple tasks through graph-partitioning to reduce compilation times. 

The graph partitioning is based on the heuristic approach presented by Moreira et al. in [*Evolutionary multi-level acyclic graph partitioning*](https://link.springer.com/article/10.1007/s10732-020-09448-8), Chapter 6. The initial partitioning has been modified for the graph-structure of SPNs. 

The partitioned tasks exchange values via memory, in future it would also be possible to concurrently launch non-depending tasks. 

The current implementation has some limitations:
* To refine the partitioning, so far only the simple move (SM) heuristic from Moreira et al. has been implemented. Improvements using the more advanced movements presented in the paper might further reduce communication cost. The existing infrastructure should make it relatively easy to implement advanced moves. See #56 
* When targeting the GPU, unnecessary copies between host and device for intermediate buffers take place. This should be optimized with a separate pass in the future. As part of this optimization, the issue of insufficient parameter space reported by `ptxas` for very large graphs should also be addressed. See #57
* Non-depending tasks could be executed concurrently using the `async`-infastructure in MLIR and the `gpu` dialect. See #58 

Next to the option to set the maximum number of operations per task (`maxTaskSize`), the PR also introduces options to specify the desired optimization level for LLVM IR and target code generation.
To this end, the Python interface now also allows to pass any option understood by the compiler through `**kwargs`, even if they are not explicitly listed in the Python interface code.

This PR implements #38 