### PR TITLE
ARM Neon SIMD support

### DIFF
--- a/compiler/include/driver/GlobalOptions.h
+++ b/compiler/include/driver/GlobalOptions.h
@@ -55,6 +55,7 @@ namespace spnc {
 
     /// Available vector libraries
     enum VectorLibrary {
+      ARM,
       SVML,
       LIBMVEC,
       NONE

--- a/compiler/include/spnc.h
+++ b/compiler/include/spnc.h
@@ -41,6 +41,11 @@ namespace spnc {
     ///         false otherwise.
     static bool isFeatureSupported(const std::string& feature);
 
+    ///
+    /// Query the compiler for information about the host default architecture.
+    /// \return The name of the host default CPU architecture.
+    static std::string getHostArchitecture();
+
   };
 }
 

--- a/compiler/src/Driver.cpp
+++ b/compiler/src/Driver.cpp
@@ -56,17 +56,21 @@ bool spn_compiler::isTargetSupported(const std::string& target){
 bool spn_compiler::isFeatureSupported(const std::string& feature){
   if(feature == "vectorize"){
       auto& targetInfo = mlir::spn::TargetInformation::nativeCPUTarget();
-      return targetInfo.hasAVXSupport() || 
-              targetInfo.hasAVX2Support() || targetInfo.hasAVX512Support();
+      return targetInfo.hasAVXSupport() ||
+          targetInfo.hasAVX2Support() || targetInfo.hasAVX512Support() ||
+          targetInfo.hasNeonSupport();
   }
-  if(feature == "AVX"){
+  if (feature == "AVX") {
     return mlir::spn::TargetInformation::nativeCPUTarget().hasAVXSupport();
   }
-  if(feature == "AVX2"){
+  if (feature == "AVX2") {
     return mlir::spn::TargetInformation::nativeCPUTarget().hasAVX2Support();
   }
-  if(feature == "AVX512"){
+  if (feature == "AVX512") {
     return mlir::spn::TargetInformation::nativeCPUTarget().hasAVX512Support();
+  }
+  if (feature == "Neon") {
+    return mlir::spn::TargetInformation::nativeCPUTarget().hasNeonSupport();
   }
   // TODO Add query support for more features.
   return false;

--- a/compiler/src/Driver.cpp
+++ b/compiler/src/Driver.cpp
@@ -75,3 +75,7 @@ bool spn_compiler::isFeatureSupported(const std::string& feature){
   // TODO Add query support for more features.
   return false;
 }
+
+std::string spn_compiler::getHostArchitecture() {
+  return mlir::spn::TargetInformation::nativeCPUTarget().getHostArchitecture();
+}

--- a/compiler/src/codegen/mlir/conversion/LoSPNtoCPUConversion.cpp
+++ b/compiler/src/codegen/mlir/conversion/LoSPNtoCPUConversion.cpp
@@ -9,9 +9,11 @@
 #include "LoSPNtoCPUConversion.h"
 #include "LoSPNtoCPU/LoSPNtoCPUConversionPasses.h"
 #include "LoSPNtoCPU/Vectorization/VectorOptimizationPasses.h"
+#include "LoSPN/LoSPNPasses.h"
 #include "mlir/Transforms/Passes.h"
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
 #include <driver/GlobalOptions.h>
+#include <TargetInformation.h>
 
 void spnc::LoSPNtoCPUConversion::initializePassPipeline(mlir::PassManager* pm, mlir::MLIRContext* ctx) {
   bool vectorize = spnc::option::cpuVectorize.get(*this->config);
@@ -30,6 +32,14 @@ void spnc::LoSPNtoCPUConversion::initializePassPipeline(mlir::PassManager* pm, m
     }
   }
   pm->addPass(mlir::spn::createLoSPNtoCPUNodeConversionPass());
+  if (mlir::spn::TargetInformation::nativeCPUTarget().isAARCH64Target() &&
+      spnc::option::vectorLibrary.get(*config) == spnc::option::VectorLibrary::ARM) {
+    // The ARM Optimized Routines are currently not available through the regular TargetLibraryInfo
+    // interface of opt/llc, so replacement with optimized implementations of elementary
+    // functions (e.g., exp, log), cannot happen in the backend. Instead, we add our own pass
+    // performing the replacement in explicitly defined cases here.
+    pm->addPass(mlir::spn::low::createReplaceARMOptimizedRoutinesPass());
+  }
   // The remaining bufferization, buffer deallocation and copy removal passes
   // currently need to be placed at this point in the pipeline, as they operate
   // on FuncOp (not SPNKernel/SPNTask) and can therefore only run after the

--- a/compiler/src/driver/action/EmitObjectCode.cpp
+++ b/compiler/src/driver/action/EmitObjectCode.cpp
@@ -40,6 +40,7 @@ spnc::ObjectFile& spnc::EmitObjectCode::execute() {
           break;
         case spnc::option::VectorLibrary::LIBMVEC:TLII.addVectorizableFunctionsFromVecLib(llvm::TargetLibraryInfoImpl::LIBMVEC_X86);
           break;
+        case spnc::option::VectorLibrary::ARM: /* ARM Optimized Routines are not available through the TLII.*/ break;
         default:SPNC_FATAL_ERROR("Unknown vector library");
       }
       pass.add(new llvm::TargetLibraryInfoWrapperPass(TLII));

--- a/compiler/src/driver/option/GlobalOptions.cpp
+++ b/compiler/src/driver/option/GlobalOptions.cpp
@@ -37,6 +37,7 @@ using spnc::option::VectorLibrary;
 EnumOpt spnc::option::vectorLibrary{"vector-library", NONE,
                                     {EnumVal(SVML, "SVML"),
                                      EnumVal(LIBMVEC, "LIBMVEC"),
+                                     EnumVal(ARM, "ARM"),
                                      EnumVal(NONE, "None")}};
 
 Option<bool> spnc::option::replaceGatherWithShuffle{"use-shuffle", false};

--- a/compiler/src/driver/toolchain/CPUToolchain.h
+++ b/compiler/src/driver/toolchain/CPUToolchain.h
@@ -25,6 +25,10 @@ namespace spnc {
     static std::unique_ptr<Job<Kernel>> constructJobFromFile(const std::string& inputFile,
                                                              const std::shared_ptr<interface::Configuration>& config);
 
+  private:
+
+    static bool validateVectorLibrary(interface::Configuration& config);
+
   };
 
 }

--- a/mlir/include/Dialect/LoSPN/LoSPNPasses.h
+++ b/mlir/include/Dialect/LoSPN/LoSPNPasses.h
@@ -22,6 +22,8 @@ namespace mlir {
 
       std::unique_ptr<OperationPass<SPNKernel>> createLoSPNPartitionerPass(int maxTaskSize = -1);
 
+      std::unique_ptr<OperationPass<ModuleOp>> createReplaceARMOptimizedRoutinesPass();
+
       /// Instantiate the graph stats collection pass determining SPN statistics like
       /// the number of inner and leaf nodes or min/max/average node level.
       /// \return Pass instance.

--- a/mlir/include/Dialect/LoSPN/LoSPNPasses.td
+++ b/mlir/include/Dialect/LoSPN/LoSPNPasses.td
@@ -31,4 +31,9 @@ def LoSPNTaskPartioning : Pass<"lospn-task-partitioning", "SPNKernel"> {
   ];
 }
 
+def ReplaceARMOptimizedRoutines : Pass<"replace-arm-optimized-routines", "ModuleOp"> {
+  let summary = "Replace elementary functions with calls to ARM optimized routines";
+  let constructor = "mlir::spn::low::createReplaceARMOptimizedRoutinesPass()";
+}
+
 #endif // MLIR_DIALECT_LoSPN_PASSES

--- a/mlir/lib/Conversion/LoSPNtoCPU/Target/TargetInformation.cpp
+++ b/mlir/lib/Conversion/LoSPNtoCPU/Target/TargetInformation.cpp
@@ -16,13 +16,25 @@
 #include "llvm/Support/raw_os_ostream.h"
 #include "mlir/IR/BuiltinTypes.h"
 
-mlir::spn::TargetInformation::TargetInformation() {
+mlir::spn::TargetInformation::TargetInformation() : hostDefaultTriple(llvm::sys::getDefaultTargetTriple()) {
   llvm::sys::getHostCPUFeatures(featureMap);
 }
 
 mlir::spn::TargetInformation& mlir::spn::TargetInformation::nativeCPUTarget() {
   static TargetInformation ti;
   return ti;
+}
+
+std::string mlir::spn::TargetInformation::getHostArchitecture() {
+  return hostDefaultTriple.getArchName().str();
+}
+
+bool mlir::spn::TargetInformation::isX8664Target() {
+  return hostDefaultTriple.getArch() == llvm::Triple::x86_64;
+}
+
+bool mlir::spn::TargetInformation::isAARCH64Target() {
+  return hostDefaultTriple.getArch() == llvm::Triple::aarch64;
 }
 
 bool mlir::spn::TargetInformation::hasAVX2Support() {

--- a/mlir/lib/Conversion/LoSPNtoCPU/Target/TargetInformation.cpp
+++ b/mlir/lib/Conversion/LoSPNtoCPU/Target/TargetInformation.cpp
@@ -37,6 +37,10 @@ bool mlir::spn::TargetInformation::hasAVXSupport() {
   return featureMap.lookup("avx");
 }
 
+bool mlir::spn::TargetInformation::hasNeonSupport() {
+  return featureMap.lookup("neon");
+}
+
 unsigned int mlir::spn::TargetInformation::getHWVectorEntries(mlir::Type type) {
   if (hasAVX512Support()) {
     return getHWVectorEntriesAVX512(type);
@@ -46,6 +50,9 @@ unsigned int mlir::spn::TargetInformation::getHWVectorEntries(mlir::Type type) {
   }
   if (hasAVXSupport()) {
     return getHWVectorEntriesAVX(type);
+  }
+  if (hasNeonSupport()) {
+    return getHWVectorEntriesNeon(type);
   }
   return 1;
 }
@@ -84,15 +91,33 @@ unsigned int mlir::spn::TargetInformation::getHWVectorEntriesAVX(mlir::Type type
 
 unsigned int mlir::spn::TargetInformation::getHWVectorEntriesAVX512(mlir::Type type) {
   if (auto intType = type.dyn_cast<IntegerType>()) {
-    // AVX2 extends most integer instructions to 256 bit.
+    // AVX-512 extends most integer instructions to 512 bit.
     return 512 / intType.getWidth();
   }
   if (auto floatType = type.dyn_cast<FloatType>()) {
     switch (floatType.getWidth()) {
       case 64: return 8;
       case 32:
-        // Float16 can only be used for store/load but not for arithmetic on most AVX2 implementations.
+        // Float16 can only be used for store/load but not for arithmetic on most AVX-512 implementations.
       default: return 16;
+    }
+  }
+  return 1;
+}
+
+unsigned int mlir::spn::TargetInformation::getHWVectorEntriesNeon(mlir::Type type) {
+  if (auto intType = type.dyn_cast<IntegerType>()) {
+    if (intType.getWidth() % 8 == 0 && intType.getWidth() <= 64) {
+      // Arm Neon supports vector operations on all integer types up to 64 bit, using 128 bit registers.
+      return 128 / intType.getWidth();
+    }
+  }
+  if (auto floatType = type.dyn_cast<FloatType>()) {
+    switch (floatType.getWidth()) {
+      case 64: return 2;
+      case 32:
+        // Float16 can only be used for store/load but not for arithmetic without the asimdhp feature.
+      default: return 4;
     }
   }
   return 1;

--- a/mlir/lib/Conversion/LoSPNtoCPU/Target/TargetInformation.h
+++ b/mlir/lib/Conversion/LoSPNtoCPU/Target/TargetInformation.h
@@ -10,6 +10,7 @@
 #define SPNC_COMPILER_SRC_DRIVER_TARGET_TARGETINFORMATION_H
 
 #include <llvm/ADT/StringMap.h>
+#include "llvm/ADT/Triple.h"
 #include "mlir/IR/Types.h"
 
 namespace mlir {
@@ -29,6 +30,12 @@ namespace mlir {
     public:
 
       static TargetInformation& nativeCPUTarget();
+
+      std::string getHostArchitecture();
+
+      bool isX8664Target();
+
+      bool isAARCH64Target();
 
       bool hasAVX2Support();
 
@@ -51,6 +58,8 @@ namespace mlir {
       unsigned getHWVectorEntriesNeon(mlir::Type type);
 
       llvm::StringMap<bool, llvm::MallocAllocator> featureMap;
+
+      llvm::Triple hostDefaultTriple;
 
     };
   }

--- a/mlir/lib/Conversion/LoSPNtoCPU/Target/TargetInformation.h
+++ b/mlir/lib/Conversion/LoSPNtoCPU/Target/TargetInformation.h
@@ -36,6 +36,8 @@ namespace mlir {
 
       bool hasAVXSupport();
 
+      bool hasNeonSupport();
+
       unsigned getHWVectorEntries(mlir::Type type);
 
     private:
@@ -45,6 +47,8 @@ namespace mlir {
       unsigned getHWVectorEntriesAVX2(mlir::Type type);
 
       unsigned getHWVectorEntriesAVX(mlir::Type type);
+
+      unsigned getHWVectorEntriesNeon(mlir::Type type);
 
       llvm::StringMap<bool, llvm::MallocAllocator> featureMap;
 

--- a/mlir/lib/Dialect/LoSPN/CMakeLists.txt
+++ b/mlir/lib/Dialect/LoSPN/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_dialect_library(MLIRLoSPN
         Passes/LoSPNCopyRemoval.cpp
         Passes/LoSPNGraphStatsCollection.cpp
         Passes/LoSPNTaskPartitioner.cpp
+        Passes/ReplaceARMOptimizedRoutines.cpp
         Bufferize/LoSPNBufferizationPatterns.cpp
         Analysis/SPNGraphStatistics.cpp
         Analysis/SPNNodeLevel.cpp
@@ -34,6 +35,7 @@ add_mlir_dialect_library(MLIRLoSPN
         MLIRPass
         MLIRTransforms
         MLIRTransformUtils
+        MLIRMath
         )
 
 include_directories(${PROJECT_SOURCE_DIR}/common/include)

--- a/mlir/lib/Dialect/LoSPN/Passes/ReplaceARMOptimizedRoutines.cpp
+++ b/mlir/lib/Dialect/LoSPN/Passes/ReplaceARMOptimizedRoutines.cpp
@@ -1,0 +1,129 @@
+//==============================================================================
+// This file is part of the SPNC project under the Apache License v2.0 by the
+// Embedded Systems and Applications Group, TU Darmstadt.
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// SPDX-License-Identifier: Apache-2.0
+//==============================================================================
+
+#include <mlir/Rewrite/FrozenRewritePatternSet.h>
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/Passes.h"
+#include "LoSPNPassDetails.h"
+#include "LoSPN/LoSPNPasses.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/SymbolTable.h"
+
+namespace mlir {
+  namespace spn {
+    namespace low {
+
+      template<typename UnOp>
+      class ReplaceUnary : public OpRewritePattern<UnOp> {
+
+        using OpRewritePattern<UnOp>::OpRewritePattern;
+
+      public:
+
+        LogicalResult matchAndRewrite(UnOp op, PatternRewriter& rewriter) const override {
+          // Perform checks, the replacement is only performed for 1D vectors.
+          if (op.operand().getType() != op.getResult().getType()) {
+            return rewriter.notifyMatchFailure(op, "Type conversion is not supported");
+          }
+          VectorType vecType = op.result().getType().template dyn_cast<VectorType>();
+          if (!vecType || vecType.getShape().size() != 1) {
+            return rewriter.notifyMatchFailure(op, "Replacement is only supported for 1D vectors");
+          }
+          // Check if the concrete pattern defines a replacement for the given vector shape and element type.
+          llvm::Optional<StringRef> funcName = getReplacementFunction(vecType);
+          if (!funcName) {
+            return rewriter.notifyMatchFailure(op, "No substitution defined for vector type and/or shape");
+          }
+          // Check if the replacement function is already present in the module (and it's symbol table).
+          // If not, create a new external function.
+          auto module = op->template getParentOfType<ModuleOp>();
+          FuncOp replaceFunc = module.template lookupSymbol<mlir::FuncOp>(funcName.getValue());
+          if (!replaceFunc) {
+            auto funcType = rewriter.getFunctionType(op.operand().getType(), op.result().getType());
+            auto restore = rewriter.saveInsertionPoint();
+            rewriter.setInsertionPointToEnd(module.getBody(0));
+            // External functions must not have public visibility, so it's marked private here.
+            replaceFunc = rewriter.create<mlir::FuncOp>(op->getLoc(), funcName.getValue(), funcType,
+                                                        rewriter.getStringAttr("private"));
+            rewriter.restoreInsertionPoint(restore);
+          }
+          rewriter.replaceOpWithNewOp<mlir::CallOp>(op, replaceFunc, op.operand());
+          return mlir::success();
+        }
+
+      protected:
+
+        virtual llvm::Optional<StringRef> getReplacementFunction(VectorType vecTy) const = 0;
+
+      private:
+
+        llvm::DenseMap<VectorType*, llvm::Optional<FuncOp>> cache;
+
+      };
+
+      class ReplaceExp : public ReplaceUnary<math::ExpOp> {
+
+        using ReplaceUnary<math::ExpOp>::ReplaceUnary;
+
+      protected:
+        Optional<StringRef> getReplacementFunction(VectorType vecTy) const override {
+          auto elemTy = vecTy.getElementType();
+          auto dim = vecTy.getShape().front();
+          if (dim == 2 && elemTy.isF64()) {
+            return StringRef("__v_exp");
+          }
+          if (dim == 4 && elemTy.isF32()) {
+            return StringRef("__v_expf");
+          }
+          return llvm::None;
+        }
+      };
+
+      class ReplaceLog : public ReplaceUnary<math::LogOp> {
+
+        using ReplaceUnary<math::LogOp>::ReplaceUnary;
+
+      protected:
+        Optional<StringRef> getReplacementFunction(VectorType vecTy) const override {
+          auto elemTy = vecTy.getElementType();
+          auto dim = vecTy.getShape().front();
+          if (dim == 2 && elemTy.isF64()) {
+            return StringRef("__v_log");
+          }
+          if (dim == 4 && elemTy.isF32()) {
+            return StringRef("__v_logf");
+          }
+          return llvm::None;
+        }
+      };
+
+      struct ReplaceARMOptimizedRoutines : public ReplaceARMOptimizedRoutinesBase<ReplaceARMOptimizedRoutines> {
+
+      protected:
+
+        void runOnOperation() override {
+          RewritePatternSet patterns(getOperation()->getContext());
+          patterns.insert<ReplaceExp, ReplaceLog>(getOperation()->getContext());
+          mlir::FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+          if (failed(applyPatternsAndFoldGreedily(getOperation(), frozenPatterns))) {
+            signalPassFailure();
+          }
+        }
+      };
+
+    }
+  }
+}
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> mlir::spn::low::createReplaceARMOptimizedRoutinesPass() {
+  return std::make_unique<ReplaceARMOptimizedRoutines>();
+}

--- a/mlir/test/lowering/lospn-to-cpu/lower-to-cpu-structure-batch-vectorize.mlir
+++ b/mlir/test/lowering/lospn-to-cpu/lower-to-cpu-structure-batch-vectorize.mlir
@@ -52,35 +52,35 @@ module  {
 // CHECK-SAME:                     %[[VAL_1:.*]]: memref<?xf64>) {
 // CHECK:           %[[VAL_2:.*]] = constant 0 : index
 // CHECK:           %[[VAL_3:.*]] = memref.dim %[[VAL_0]], %[[VAL_2]] : memref<?x6xf64>
-// CHECK:           %[[VAL_4:.*]] = constant 4 : index
+// CHECK:           %[[VAL_4:.*]] = constant [[#VEC:]] : index
 // CHECK:           %[[VAL_5:.*]] = remi_unsigned %[[VAL_3]], %[[VAL_4]] : index
 // CHECK:           %[[VAL_6:.*]] = subi %[[VAL_3]], %[[VAL_5]] : index
 // CHECK:           %[[VAL_7:.*]] = constant 0 : index
-// CHECK:           %[[VAL_8:.*]] = constant 4 : index
+// CHECK:           %[[VAL_8:.*]] = constant [[#VEC]] : index
 // CHECK:           scf.for %[[VAL_9:.*]] = %[[VAL_7]] to %[[VAL_6]] step %[[VAL_8]] {
-// CHECK:             %[[VAL_10:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 0 : ui32, vector_width = 4 : i32} : (memref<?x6xf64>, index) -> f64
-// CHECK:             %[[VAL_11:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 1 : ui32, vector_width = 4 : i32} : (memref<?x6xf64>, index) -> f64
-// CHECK:             %[[VAL_12:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 2 : ui32, vector_width = 4 : i32} : (memref<?x6xf64>, index) -> f64
-// CHECK:             %[[VAL_13:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 3 : ui32, vector_width = 4 : i32} : (memref<?x6xf64>, index) -> f64
-// CHECK:             %[[VAL_14:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 4 : ui32, vector_width = 4 : i32} : (memref<?x6xf64>, index) -> f64
-// CHECK:             %[[VAL_15:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 5 : ui32, vector_width = 4 : i32} : (memref<?x6xf64>, index) -> f64
-// CHECK:             %[[VAL_16:.*]] = "lo_spn.categorical"(%[[VAL_10]]) {probabilities = [3.500000e-01, 5.500000e-01, 1.000000e-01], supportMarginal = false, vector_width = 4 : i32} : (f64) -> f64
-// CHECK:             %[[VAL_17:.*]] = "lo_spn.categorical"(%[[VAL_11]]) {probabilities = [2.500000e-01, 6.250000e-01, 1.250000e-01], supportMarginal = false, vector_width = 4 : i32} : (f64) -> f64
-// CHECK:             %[[VAL_18:.*]] = "lo_spn.histogram"(%[[VAL_12]]) {bucketCount = 2 : ui32, buckets = [{lb = 0 : i32, ub = 1 : i32, val = 2.500000e-01 : f64}, {lb = 1 : i32, ub = 2 : i32, val = 7.500000e-01 : f64}], supportMarginal = false, vector_width = 4 : i32} : (f64) -> f64
-// CHECK:             %[[VAL_19:.*]] = "lo_spn.histogram"(%[[VAL_13]]) {bucketCount = 2 : ui32, buckets = [{lb = 0 : i32, ub = 1 : i32, val = 4.500000e-01 : f64}, {lb = 1 : i32, ub = 2 : i32, val = 5.500000e-01 : f64}], supportMarginal = false, vector_width = 4 : i32} : (f64) -> f64
-// CHECK:             %[[VAL_20:.*]] = "lo_spn.gaussian"(%[[VAL_14]]) {mean = 5.000000e-01 : f64, stddev = 1.000000e+00 : f64, supportMarginal = false, vector_width = 4 : i32} : (f64) -> f64
-// CHECK:             %[[VAL_21:.*]] = "lo_spn.gaussian"(%[[VAL_15]]) {mean = 2.500000e-01 : f64, stddev = 1.000000e-01 : f64, supportMarginal = false, vector_width = 4 : i32} : (f64) -> f64
-// CHECK:             %[[VAL_22:.*]] = "lo_spn.mul"(%[[VAL_16]], %[[VAL_17]]) {vector_width = 4 : i32} : (f64, f64) -> f64
-// CHECK:             %[[VAL_23:.*]] = "lo_spn.mul"(%[[VAL_22]], %[[VAL_18]]) {vector_width = 4 : i32} : (f64, f64) -> f64
-// CHECK:             %[[VAL_24:.*]] = "lo_spn.constant"() {type = f64, value = 1.000000e-01 : f64, vector_width = 4 : i32} : () -> f64
-// CHECK:             %[[VAL_25:.*]] = "lo_spn.mul"(%[[VAL_23]], %[[VAL_24]]) {vector_width = 4 : i32} : (f64, f64) -> f64
-// CHECK:             %[[VAL_26:.*]] = "lo_spn.mul"(%[[VAL_19]], %[[VAL_20]]) {vector_width = 4 : i32} : (f64, f64) -> f64
-// CHECK:             %[[VAL_27:.*]] = "lo_spn.mul"(%[[VAL_26]], %[[VAL_21]]) {vector_width = 4 : i32} : (f64, f64) -> f64
-// CHECK:             %[[VAL_28:.*]] = "lo_spn.constant"() {type = f64, value = 1.000000e-01 : f64, vector_width = 4 : i32} : () -> f64
-// CHECK:             %[[VAL_29:.*]] = "lo_spn.mul"(%[[VAL_27]], %[[VAL_28]]) {vector_width = 4 : i32} : (f64, f64) -> f64
-// CHECK:             %[[VAL_30:.*]] = "lo_spn.add"(%[[VAL_25]], %[[VAL_29]]) {vector_width = 4 : i32} : (f64, f64) -> f64
-// CHECK:             %[[VAL_31:.*]] = "lo_spn.log"(%[[VAL_30]]) {vector_width = 4 : i32} : (f64) -> f64
-// CHECK:             "lo_spn.batch_write"(%[[VAL_31]], %[[VAL_1]], %[[VAL_9]]) {vector_width = 4 : i32} : (f64, memref<?xf64>, index) -> ()
+// CHECK:             %[[VAL_10:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 0 : ui32, vector_width = [[#VEC]] : i32} : (memref<?x6xf64>, index) -> f64
+// CHECK:             %[[VAL_11:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 1 : ui32, vector_width = [[#VEC]] : i32} : (memref<?x6xf64>, index) -> f64
+// CHECK:             %[[VAL_12:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 2 : ui32, vector_width = [[#VEC]] : i32} : (memref<?x6xf64>, index) -> f64
+// CHECK:             %[[VAL_13:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 3 : ui32, vector_width = [[#VEC]] : i32} : (memref<?x6xf64>, index) -> f64
+// CHECK:             %[[VAL_14:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 4 : ui32, vector_width = [[#VEC]] : i32} : (memref<?x6xf64>, index) -> f64
+// CHECK:             %[[VAL_15:.*]] = "lo_spn.batch_read"(%[[VAL_0]], %[[VAL_9]]) {sampleIndex = 5 : ui32, vector_width = [[#VEC]] : i32} : (memref<?x6xf64>, index) -> f64
+// CHECK:             %[[VAL_16:.*]] = "lo_spn.categorical"(%[[VAL_10]]) {probabilities = [3.500000e-01, 5.500000e-01, 1.000000e-01], supportMarginal = false, vector_width = [[#VEC]] : i32} : (f64) -> f64
+// CHECK:             %[[VAL_17:.*]] = "lo_spn.categorical"(%[[VAL_11]]) {probabilities = [2.500000e-01, 6.250000e-01, 1.250000e-01], supportMarginal = false, vector_width = [[#VEC]] : i32} : (f64) -> f64
+// CHECK:             %[[VAL_18:.*]] = "lo_spn.histogram"(%[[VAL_12]]) {bucketCount = 2 : ui32, buckets = [{lb = 0 : i32, ub = 1 : i32, val = 2.500000e-01 : f64}, {lb = 1 : i32, ub = 2 : i32, val = 7.500000e-01 : f64}], supportMarginal = false, vector_width = [[#VEC]] : i32} : (f64) -> f64
+// CHECK:             %[[VAL_19:.*]] = "lo_spn.histogram"(%[[VAL_13]]) {bucketCount = 2 : ui32, buckets = [{lb = 0 : i32, ub = 1 : i32, val = 4.500000e-01 : f64}, {lb = 1 : i32, ub = 2 : i32, val = 5.500000e-01 : f64}], supportMarginal = false, vector_width = [[#VEC]] : i32} : (f64) -> f64
+// CHECK:             %[[VAL_20:.*]] = "lo_spn.gaussian"(%[[VAL_14]]) {mean = 5.000000e-01 : f64, stddev = 1.000000e+00 : f64, supportMarginal = false, vector_width = [[#VEC]] : i32} : (f64) -> f64
+// CHECK:             %[[VAL_21:.*]] = "lo_spn.gaussian"(%[[VAL_15]]) {mean = 2.500000e-01 : f64, stddev = 1.000000e-01 : f64, supportMarginal = false, vector_width = [[#VEC]] : i32} : (f64) -> f64
+// CHECK:             %[[VAL_22:.*]] = "lo_spn.mul"(%[[VAL_16]], %[[VAL_17]]) {vector_width = [[#VEC]] : i32} : (f64, f64) -> f64
+// CHECK:             %[[VAL_23:.*]] = "lo_spn.mul"(%[[VAL_22]], %[[VAL_18]]) {vector_width = [[#VEC]] : i32} : (f64, f64) -> f64
+// CHECK:             %[[VAL_24:.*]] = "lo_spn.constant"() {type = f64, value = 1.000000e-01 : f64, vector_width = [[#VEC]] : i32} : () -> f64
+// CHECK:             %[[VAL_25:.*]] = "lo_spn.mul"(%[[VAL_23]], %[[VAL_24]]) {vector_width = [[#VEC]] : i32} : (f64, f64) -> f64
+// CHECK:             %[[VAL_26:.*]] = "lo_spn.mul"(%[[VAL_19]], %[[VAL_20]]) {vector_width = [[#VEC]] : i32} : (f64, f64) -> f64
+// CHECK:             %[[VAL_27:.*]] = "lo_spn.mul"(%[[VAL_26]], %[[VAL_21]]) {vector_width = [[#VEC]] : i32} : (f64, f64) -> f64
+// CHECK:             %[[VAL_28:.*]] = "lo_spn.constant"() {type = f64, value = 1.000000e-01 : f64, vector_width = [[#VEC]] : i32} : () -> f64
+// CHECK:             %[[VAL_29:.*]] = "lo_spn.mul"(%[[VAL_27]], %[[VAL_28]]) {vector_width = [[#VEC]] : i32} : (f64, f64) -> f64
+// CHECK:             %[[VAL_30:.*]] = "lo_spn.add"(%[[VAL_25]], %[[VAL_29]]) {vector_width = [[#VEC]] : i32} : (f64, f64) -> f64
+// CHECK:             %[[VAL_31:.*]] = "lo_spn.log"(%[[VAL_30]]) {vector_width = [[#VEC]] : i32} : (f64) -> f64
+// CHECK:             "lo_spn.batch_write"(%[[VAL_31]], %[[VAL_1]], %[[VAL_9]]) {vector_width = [[#VEC]] : i32} : (f64, memref<?xf64>, index) -> ()
 // CHECK:           }
 // CHECK:           %[[VAL_32:.*]] = constant 1 : index
 // CHECK:           scf.for %[[VAL_33:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_32]] {

--- a/python-interface/src/python-interface.cpp
+++ b/python-interface/src/python-interface.cpp
@@ -51,11 +51,14 @@ PYBIND11_MODULE(spncpy, m) {
       .def("compileQuery", [](const spn_compiler& compiler, const std::string& inputFile, const options_t& options) {
         return spn_compiler::compileQuery(inputFile, options);
       })
-      .def("isTargetSupported", [](const std::string& target){
+      .def("isTargetSupported", [](const std::string& target) {
         return spn_compiler::isTargetSupported(target);
       })
-      .def("isFeatureAvailable", [](const std::string& feature){
+      .def("isFeatureAvailable", [](const std::string& feature) {
         return spn_compiler::isFeatureSupported(feature);
+      })
+      .def("getHostArchitecture", []() {
+        return spn_compiler::getHostArchitecture();
       });
 
 }


### PR DESCRIPTION
Add support for vectorization on ARM platforms, specifically ARM v8 aarch64 with Neon advanced SIMD extensions. 

For elementary functions (e.g., `exp`, `log`), the optimized implementations from the [ARM Optimized Routines library](https://github.com/ARM-software/optimized-routines) can be used with `ARM` as vector library. 
As the Optimized Routines are currently not part of the available vector libraries for the LLVM backend, the replacement is performed by a custom MLIR pass in `spnc`. 