### PR TITLE
CUDA Unified Memory Support

### DIFF
--- a/CudaToolkit.cmake
+++ b/CudaToolkit.cmake
@@ -26,26 +26,4 @@ macro(cuda_setup)
         message(STATUS "Using CUDA runtime library: " ${CUDA_RUNTIME_LIBRARY})
     endif ()
 
-    # When compiling for CUDA GPUs, the generated Kernel must be linked with the
-    # MLIR CUDA runtime wrappers for data-transfer, kernel-launch etc.
-    # When building static libraries, we want to create a complete Python package, and
-    # include the MLIR CUDA wrapper library, which the compiled kernels for the GPU target need
-    # in the Python wheel.
-    find_library(MLIR_CUDA_WRAPPERS mlir_cuda_runtime HINTS ${LLVM_BUILD_LIBRARY_DIR})
-    if (NOT MLIR_CUDA_WRAPPERS)
-        message(FATAL_ERROR "MLIR CUDA wrappers not found.")
-    else ()
-        # Resolve symbolic link if necessary.
-        if(IS_SYMLINK ${MLIR_CUDA_WRAPPERS})
-            file(READ_SYMLINK ${MLIR_CUDA_WRAPPERS} MLIR_CUDA_SYM)
-            if(NOT IS_ABSOLUTE "${MLIR_CUDA_SYM}")
-                get_filename_component(dir "${MLIR_CUDA_WRAPPERS}" DIRECTORY)
-                set(MLIR_CUDA_WRAPPERS "${dir}/${MLIR_CUDA_SYM}")
-            else()
-                set(MLIR_CUDA_WRAPPERS "${MLIR_CUDA_SYM}")
-            endif()
-        endif()
-        message(STATUS "Using MLIR CUDA wrappers: ${MLIR_CUDA_WRAPPERS}")
-    endif()
-
 endmacro(cuda_setup)

--- a/compiler/src/driver/toolchain/CUDAGPUToolchain.cpp
+++ b/compiler/src/driver/toolchain/CUDAGPUToolchain.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<Job<Kernel> > CUDAGPUToolchain::constructJobFromFile(const std::
   SPDLOG_INFO("Compiling to shared object file {}", sharedObject.fileName());
   // The generated kernel must be linked against the MLIR CUDA runtime wrappers.
   llvm::SmallVector<std::string, 3> additionalLibs;
-  additionalLibs.push_back("mlir_cuda_runtime");
+  additionalLibs.push_back("spnc-cuda-wrappers");
   auto searchPaths = parseLibrarySearchPaths(spnc::option::searchPaths.get(*config));
   searchPaths.push_back(SPNC_CUDA_RUNTIME_WRAPPERS_DIR);
   (void) job->insertFinalAction<ClangKernelLinking>(emitObjectCode, std::move(sharedObject), kernelInfo,

--- a/python-interface/CMakeLists.txt
+++ b/python-interface/CMakeLists.txt
@@ -19,18 +19,16 @@ target_include_directories(spncpy
 
 # Create the setup.py and supplement some information from the CMake configure and generate stage.
 # This is a multi-stage process, because we first need to use configure_file to supplement 
-# configuration variables (used for the MLIR CUDA runtime wrapper library) and then need 
-# to substiture the generator expressions used to add target information to the setup.py
+# configuration variables (used for the SPNC CUDA runtime wrapper library) and then need
+# to substitute the generator expressions used to add target information to the setup.py
 if (${CUDA_GPU_SUPPORT})
     set(INCLUDE_MLIR_CUDA_WRAPPERS "True")
     # Copy MLIR CUDA wrappers to spnc package directory.
     add_custom_command(TARGET spncpy POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
-            ${MLIR_CUDA_WRAPPERS} ${CMAKE_CURRENT_SOURCE_DIR}/spnc)
-    get_filename_component(MLIR_CUDA_WRAPPER_NAME ${MLIR_CUDA_WRAPPERS} NAME)
+            $<TARGET_FILE:spnc-cuda-wrappers> ${CMAKE_CURRENT_SOURCE_DIR}/spnc)
 else ()
     set(INCLUDE_MLIR_CUDA_WRAPPERS "False")
-    set(MLIR_CUDA_WRAPPER_NAME "")
 endif ()
 
 # Copy the spnc Python interface module/library to the spnc package directory.

--- a/python-interface/CMakeLists.txt
+++ b/python-interface/CMakeLists.txt
@@ -23,12 +23,14 @@ target_include_directories(spncpy
 # to substitute the generator expressions used to add target information to the setup.py
 if (${CUDA_GPU_SUPPORT})
     set(INCLUDE_MLIR_CUDA_WRAPPERS "True")
+    set(SPNC_MLIR_CUDA_WRAPPERS "$<TARGET_FILE_NAME:spnc-cuda-wrappers>")
     # Copy MLIR CUDA wrappers to spnc package directory.
     add_custom_command(TARGET spncpy POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
             $<TARGET_FILE:spnc-cuda-wrappers> ${CMAKE_CURRENT_SOURCE_DIR}/spnc)
 else ()
     set(INCLUDE_MLIR_CUDA_WRAPPERS "False")
+    set(SPNC_MLIR_CUDA_WRAPPERS "NO_CUDA_SUPPORT")
 endif ()
 
 # Copy the spnc Python interface module/library to the spnc package directory.

--- a/python-interface/setup.py.in
+++ b/python-interface/setup.py.in
@@ -14,10 +14,10 @@ import shutil
 import os
 
 if @INCLUDE_MLIR_CUDA_WRAPPERS@:
-    cudaWrappers = os.path.join(os.path.realpath(os.path.dirname(__file__)), "spnc", "@MLIR_CUDA_WRAPPER_NAME@")
+    cudaWrappers = os.path.join(os.path.realpath(os.path.dirname(__file__)), "spnc", "$<TARGET_FILE_NAME:spnc-cuda-wrappers>")
     if not os.path.isfile(cudaWrappers):
         raise RuntimeError("MLIR CUDA wrappers not found")
-    binaryPackages = ["$<TARGET_FILE_NAME:spncpy>", "@MLIR_CUDA_WRAPPER_NAME@"]
+    binaryPackages = ["$<TARGET_FILE_NAME:spncpy>", "$<TARGET_FILE_NAME:spnc-cuda-wrappers>"]
 else:
     binaryPackages = ["$<TARGET_FILE_NAME:spncpy>"]
 

--- a/python-interface/setup.py.in
+++ b/python-interface/setup.py.in
@@ -14,10 +14,10 @@ import shutil
 import os
 
 if @INCLUDE_MLIR_CUDA_WRAPPERS@:
-    cudaWrappers = os.path.join(os.path.realpath(os.path.dirname(__file__)), "spnc", "$<TARGET_FILE_NAME:spnc-cuda-wrappers>")
+    cudaWrappers = os.path.join(os.path.realpath(os.path.dirname(__file__)), "spnc", "@SPNC_MLIR_CUDA_WRAPPERS@")
     if not os.path.isfile(cudaWrappers):
         raise RuntimeError("MLIR CUDA wrappers not found")
-    binaryPackages = ["$<TARGET_FILE_NAME:spncpy>", "$<TARGET_FILE_NAME:spnc-cuda-wrappers>"]
+    binaryPackages = ["$<TARGET_FILE_NAME:spncpy>", "@SPNC_MLIR_CUDA_WRAPPERS@"]
 else:
     binaryPackages = ["$<TARGET_FILE_NAME:spncpy>"]
 

--- a/python-interface/spnc/gpu.py
+++ b/python-interface/spnc/gpu.py
@@ -149,7 +149,7 @@ class CUDACompiler:
         # the same location as the spncpy compiled module. 
         # We try to locate the library in this directory and load it.
         libraryDir = os.path.realpath(os.path.dirname(spncpy.__file__))
-        pattern = os.path.join(libraryDir, "libmlir_cuda_runtime.so*")
+        pattern = os.path.join(libraryDir, "libspnc-cuda-wrappers.so*")
         candidates = glob.glob(pattern)
         if not candidates:
             print(f"WARNING: Did not find MLIR CUDA runtime wrappers in {libraryDir}")

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -39,3 +39,5 @@ doxygen_doc(TARGET_NAME spnc-rt
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         DEPENDS
         spnc-common)
+
+add_subdirectory(wrappers)

--- a/runtime/wrappers/CMakeLists.txt
+++ b/runtime/wrappers/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(cuda)

--- a/runtime/wrappers/CMakeLists.txt
+++ b/runtime/wrappers/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_subdirectory(cuda)
+if (${CUDA_GPU_SUPPORT})
+    # Only build the runtime wrapper library if CUDA support was requested.
+    add_subdirectory(cuda)
+endif (${CUDA_GPU_SUPPORT})

--- a/runtime/wrappers/cuda/CMakeLists.txt
+++ b/runtime/wrappers/cuda/CMakeLists.txt
@@ -7,3 +7,14 @@ add_library(spnc-cuda-wrappers SHARED
 target_include_directories(spnc-cuda-wrappers PRIVATE ${CUDA_INCLUDE_DIRS})
 
 target_link_libraries(spnc-cuda-wrappers PRIVATE ${CUDA_RUNTIME_LIBRARY})
+
+option(CUDA_UNIFIED_MEMORY
+        "Enable/Disable support for unified memory usage for CUDA GPUs."
+        OFF
+        )
+
+if (${CUDA_UNIFIED_MEMORY})
+    target_compile_definitions(spnc-cuda-wrappers PRIVATE SPNC_CUDA_UNIFIED_MEMORY=1)
+else (${CUDA_UNIFIED_MEMORY})
+    target_compile_definitions(spnc-cuda-wrappers PRIVATE SPNC_CUDA_UNIFIED_MEMORY=0)
+endif (${CUDA_UNIFIED_MEMORY})

--- a/runtime/wrappers/cuda/CMakeLists.txt
+++ b/runtime/wrappers/cuda/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(spnc-cuda-wrappers SHARED
+
+        CUDARuntimeWrappers.cpp
+        )
+
+
+target_include_directories(spnc-cuda-wrappers PRIVATE ${CUDA_INCLUDE_DIRS})
+
+target_link_libraries(spnc-cuda-wrappers PRIVATE ${CUDA_RUNTIME_LIBRARY})

--- a/runtime/wrappers/cuda/CUDARuntimeWrappers.cpp
+++ b/runtime/wrappers/cuda/CUDARuntimeWrappers.cpp
@@ -1,0 +1,145 @@
+//==============================================================================
+// This file is part of the SPNC project under the Apache License v2.0 by the
+// Embedded Systems and Applications Group, TU Darmstadt.
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// SPDX-License-Identifier: Apache-2.0
+//==============================================================================
+
+// This file is a modified copy of CudaRuntimeWrappers.cpp in mlir/lib/ExecutionEngine in the LLVM repository.
+
+#include <cassert>
+#include <numeric>
+#include <iostream>
+
+#include "cuda.h"
+
+#ifdef _WIN32
+#define MLIR_CUDA_WRAPPERS_EXPORT __declspec(dllexport)
+#else
+#define MLIR_CUDA_WRAPPERS_EXPORT
+#endif // _WIN32
+
+#define CUDA_REPORT_IF_ERROR(expr)                                             \
+  [](CUresult result) {                                                        \
+    if (!result)                                                               \
+      return;                                                                  \
+    const char *name = nullptr;                                                \
+    cuGetErrorName(result, &name);                                             \
+    if (!name)                                                                 \
+      name = "<unknown>";                                                      \
+    fprintf(stderr, "'%s' failed with '%s'\n", #expr, name);                   \
+  }(expr)
+
+// Make the primary context of device 0 current for the duration of the instance
+// and restore the previous context on destruction.
+class ScopedContext {
+public:
+  ScopedContext() {
+    // Static reference to CUDA primary context for device ordinal 0.
+    static CUcontext context = [] {
+      CUDA_REPORT_IF_ERROR(cuInit(/*flags=*/0));
+      CUdevice device;
+      CUDA_REPORT_IF_ERROR(cuDeviceGet(&device, /*ordinal=*/0));
+      CUcontext ctx;
+      // Note: this does not affect the current context.
+      CUDA_REPORT_IF_ERROR(cuDevicePrimaryCtxRetain(&ctx, device));
+      return ctx;
+    }();
+
+    CUDA_REPORT_IF_ERROR(cuCtxPushCurrent(context));
+  }
+
+  ~ScopedContext() { CUDA_REPORT_IF_ERROR(cuCtxPopCurrent(nullptr)); }
+};
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT CUmodule mgpuModuleLoad(void* data) {
+  ScopedContext scopedContext;
+  CUmodule module = nullptr;
+  CUDA_REPORT_IF_ERROR(cuModuleLoadData(&module, data));
+  return module;
+}
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuModuleUnload(CUmodule module) {
+  CUDA_REPORT_IF_ERROR(cuModuleUnload(module));
+}
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT CUfunction
+mgpuModuleGetFunction(CUmodule module, const char* name) {
+  CUfunction function = nullptr;
+  CUDA_REPORT_IF_ERROR(cuModuleGetFunction(&function, module, name));
+  return function;
+}
+
+// The wrapper uses intptr_t instead of CUDA's unsigned int to match
+// the type of MLIR's index type. This avoids the need for casts in the
+// generated MLIR code.
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void
+mgpuLaunchKernel(CUfunction function, intptr_t gridX, intptr_t gridY,
+                 intptr_t gridZ, intptr_t blockX, intptr_t blockY,
+                 intptr_t blockZ, int32_t smem, CUstream stream, void** params,
+                 void** extra) {
+  ScopedContext scopedContext;
+  CUDA_REPORT_IF_ERROR(cuLaunchKernel(function, gridX, gridY, gridZ, blockX,
+                                      blockY, blockZ, smem, stream, params,
+                                      extra));
+}
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT CUstream mgpuStreamCreate() {
+  ScopedContext scopedContext;
+  CUstream stream = nullptr;
+  CUDA_REPORT_IF_ERROR(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+  return stream;
+}
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuStreamDestroy(CUstream stream) {
+  CUDA_REPORT_IF_ERROR(cuStreamDestroy(stream));
+}
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void
+mgpuStreamSynchronize(CUstream stream) {
+  CUDA_REPORT_IF_ERROR(cuStreamSynchronize(stream));
+}
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuStreamWaitEvent(CUstream stream,
+                                                              CUevent event) {
+  CUDA_REPORT_IF_ERROR(cuStreamWaitEvent(stream, event, /*flags=*/0));
+}
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT CUevent mgpuEventCreate() {
+  ScopedContext scopedContext;
+  CUevent event = nullptr;
+  CUDA_REPORT_IF_ERROR(cuEventCreate(&event, CU_EVENT_DISABLE_TIMING));
+  return event;
+}
+
+extern "C" MLIR_CUDA_WRAPPERS_EXPORT void mgpuEventDestroy(CUevent event) {
+  CUDA_REPORT_IF_ERROR(cuEventDestroy(event));
+}
+
+extern MLIR_CUDA_WRAPPERS_EXPORT "C" void mgpuEventSynchronize(CUevent event) {
+  CUDA_REPORT_IF_ERROR(cuEventSynchronize(event));
+}
+
+extern MLIR_CUDA_WRAPPERS_EXPORT "C" void mgpuEventRecord(CUevent event,
+                                                          CUstream stream) {
+  CUDA_REPORT_IF_ERROR(cuEventRecord(event, stream));
+}
+
+extern "C" void* mgpuMemAlloc(uint64_t sizeBytes, CUstream /*stream*/) {
+  ScopedContext scopedContext;
+  CUdeviceptr ptr;
+  CUDA_REPORT_IF_ERROR(cuMemAlloc(&ptr, sizeBytes));
+  return reinterpret_cast<void*>(ptr);
+}
+
+extern "C" void mgpuMemFree(void* ptr, CUstream /*stream*/) {
+  CUDA_REPORT_IF_ERROR(cuMemFree(reinterpret_cast<CUdeviceptr>(ptr)));
+}
+
+extern "C" void mgpuMemcpy(void* dst, void* src, uint64_t sizeBytes,
+                           CUstream stream) {
+  CUDA_REPORT_IF_ERROR(cuMemcpyAsync(reinterpret_cast<CUdeviceptr>(dst),
+                                     reinterpret_cast<CUdeviceptr>(src),
+                                     sizeBytes, stream));
+}


### PR DESCRIPTION
Optionally (disabled by default) assume CUDA unified memory when targeting the GPU, eliminating data transfers in cases where host and GPU share the same physical memory. 

Uses own, modified version of the MLIR CUDA runtime wrappers for implementation. 